### PR TITLE
[BFO-340] Convert scan duration to int instead of float

### DIFF
--- a/pkg/report/model/utils.go
+++ b/pkg/report/model/utils.go
@@ -16,7 +16,7 @@ const (
 )
 
 func GetScanDurationTag(summary model.Summary) string {
-	scanDuration := summary.Times.End.Sub(summary.Times.Start).Seconds()
+	scanDuration := int(summary.Times.End.Sub(summary.Times.Start).Seconds())
 	executionTimeTag := fmt.Sprintf(executionTimeTag, scanDuration)
 	return executionTimeTag
 }


### PR DESCRIPTION
SA sarif processor expects the scan duration to be an int instead of a float.