### PR TITLE
[BFO-342] Add analyzer stats to scan execution

### DIFF
--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func ExecuteScan(scanParams *scan.Parameters) error {
+func ExecuteScan(scanParams *scan.Parameters) (scan.ScanMetadata, error) {
 	log.Debug().Msg("console.scan()")
 	ctx := context.Background()
 
@@ -24,15 +24,15 @@ func ExecuteScan(scanParams *scan.Parameters) error {
 
 	if err != nil {
 		log.Err(err).Msgf("failed to create scan client%v", err)
-		return err
+		return scan.ScanMetadata{}, err
 	}
 
-	err = client.PerformScan(ctx)
+	scanMetadata, err := client.PerformScan(ctx)
 
 	if err != nil {
 		log.Err(err).Msgf("failed to perform scan: %v", err)
-		return err
+		return scan.ScanMetadata{}, err
 	}
 
-	return nil
+	return scanMetadata, nil
 }

--- a/kics.go
+++ b/kics.go
@@ -4,7 +4,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
 
-package kics
+package main
 
 import (
 	"log"
@@ -15,16 +15,30 @@ import (
 	"github.com/Checkmarx/kics/pkg/scan"
 )
 
-func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) string {
+func main() {
+	inputPaths := []string{
+		"/Users/bahar.shah/go/src/github.com/DataDog/innovation-week-cloud-to-tf/terraform/ami.tf",
+	}
+	outputPath := "/Users/bahar.shah/go/src/github.com/DataDog/innovation-week-cloud-to-tf"
+	sci := model.SCIInfo{
+		DiffAware: model.DiffAware{
+			Enabled: false,
+		},
+	}
+	ExecuteKICSScan(inputPaths, outputPath, sci)
+}
+
+func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string) {
 	params := scan.GetDefaultParameters()
 	params.Path = inputPaths
 	params.OutputPath = outputPath
 	params.SCIInfo = sciInfo
-	err := console.ExecuteScan(params)
+	metadata, err := console.ExecuteScan(params)
 	if err != nil {
 		log.Fatalf("failed to execute scan: %v", err)
-		return ""
+		return scan.ScanMetadata{}, ""
 	}
+	log.Printf("Scan completed successfully with metadata: %v", metadata)
 	resultsFile := filepath.Join(outputPath, params.OutputName)
-	return resultsFile
+	return metadata, resultsFile
 }

--- a/kics.go
+++ b/kics.go
@@ -4,7 +4,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
 
-package main
+package kics
 
 import (
 	"log"
@@ -14,19 +14,6 @@ import (
 	"github.com/Checkmarx/kics/pkg/model"
 	"github.com/Checkmarx/kics/pkg/scan"
 )
-
-func main() {
-	inputPaths := []string{
-		"/Users/bahar.shah/go/src/github.com/DataDog/innovation-week-cloud-to-tf/terraform/ami.tf",
-	}
-	outputPath := "/Users/bahar.shah/go/src/github.com/DataDog/innovation-week-cloud-to-tf"
-	sci := model.SCIInfo{
-		DiffAware: model.DiffAware{
-			Enabled: false,
-		},
-	}
-	ExecuteKICSScan(inputPaths, outputPath, sci)
-}
 
 func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string) {
 	params := scan.GetDefaultParameters()

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -508,7 +508,7 @@ func TestInspector_DecodeQueryResults(t *testing.T) {
 			//create a context with 0 second to timeout
 			timeoutDuration, _ := time.ParseDuration(tt.args.timeDuration)
 			myCtxTimeOut, _ := context.WithTimeout(contextToUSe, timeoutDuration)
-			result, err := c.DecodeQueryResults(&tt.args.queryContext, myCtxTimeOut, tt.args.regoResult)
+			result, err := c.DecodeQueryResults(&tt.args.queryContext, myCtxTimeOut, tt.args.regoResult, 57)
 			assert.Nil(t, err, "Error not as expected")
 			assert.Equal(t, 0, len(result), "Array size is not as expected")
 		})
@@ -552,7 +552,7 @@ func newQueryContext(ctx context.Context) QueryContext {
 func newInspectorInstance(t *testing.T, queryPath []string, kicsComputeNewSimID bool) *Inspector {
 	querySource := source.NewFilesystemSource(queryPath, []string{""}, []string{""}, filepath.FromSlash("./assets/libraries"), true)
 	var vb = func(ctx *QueryContext, tracker Tracker, v interface{},
-		detector *detector.DetectLine, useOldSeverity bool, kicsComputeNewSimID bool) (*model.Vulnerability, error) {
+		detector *detector.DetectLine, useOldSeverity bool, kicsComputeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error) {
 		return &model.Vulnerability{}, nil
 	}
 	ins, err := NewInspector(

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -8,6 +8,7 @@ package engine
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	dec "github.com/Checkmarx/kics/pkg/detector"
 	"github.com/Checkmarx/kics/pkg/engine/similarity"
@@ -63,7 +64,8 @@ var DefaultVulnerabilityBuilder = func(ctx *QueryContext,
 	v interface{},
 	detector *dec.DetectLine,
 	useOldSeverities bool,
-	kicsComputeNewSimID bool) (*model.Vulnerability, error) {
+	kicsComputeNewSimID bool,
+	queryDuration time.Duration) (*model.Vulnerability, error) {
 	vObj, ok := v.(map[string]interface{})
 	if !ok {
 		return &model.Vulnerability{}, ErrInvalidResult
@@ -206,6 +208,7 @@ var DefaultVulnerabilityBuilder = func(ctx *QueryContext,
 		CloudProvider:    getCloudProvider(overrideKey, vObj, &logWithFields),
 		Remediation:      PtrStringToString(mustMapKeyToString(vObj, "remediation")),
 		RemediationType:  PtrStringToString(mustMapKeyToString(vObj, "remediationType")),
+		QueryDuration:    queryDuration,
 	}, nil
 }
 

--- a/pkg/engine/vulnerability_builder_test.go
+++ b/pkg/engine/vulnerability_builder_test.go
@@ -432,7 +432,7 @@ func TestDefaultVulnerabilityBuilder(t *testing.T) {
 	for _, tt := range vbTests {
 		insDetector := detector.NewDetectLine(3)
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DefaultVulnerabilityBuilder(tt.args.ctx, tt.args.tracker, tt.args.v, insDetector, tt.useNewVulnerability, tt.kicsComputeNewSimID)
+			got, err := DefaultVulnerabilityBuilder(tt.args.ctx, tt.args.tracker, tt.args.v, insDetector, tt.useNewVulnerability, tt.kicsComputeNewSimID, 57)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("test[%s] DefaultVulnerabilityBuilder() error %v, wantErr %v", tt.name, err, tt.wantErr)
 				return

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -202,6 +203,7 @@ type Vulnerability struct {
 	CloudProvider    string           `json:"cloud_provider"`
 	Remediation      string           `db:"remediation" json:"remediation"`
 	RemediationType  string           `db:"remediation_type" json:"remediation_type"`
+	QueryDuration    time.Duration    `json:"query_duration"`
 }
 
 // QueryConfig is a struct that contains the fileKind and platform of the rego query

--- a/pkg/remediation/scan.go
+++ b/pkg/remediation/scan.go
@@ -157,6 +157,7 @@ func getPayload(filePath string, content []byte, openAPIResolveReferences bool, 
 
 // runQuery runs a query and returns its results
 func runQuery(r *runQueryInfo) []model.Vulnerability {
+	queryStart := time.Now()
 	queryExecTimeout := time.Duration(60) * time.Second
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), queryExecTimeout)
@@ -185,7 +186,7 @@ func runQuery(r *runQueryInfo) []model.Vulnerability {
 
 	timeoutCtxToDecode, cancelDecode := context.WithTimeout(context.Background(), queryExecTimeout)
 	defer cancelDecode()
-	decoded, err := r.inspector.DecodeQueryResults(queryCtx, timeoutCtxToDecode, results)
+	decoded, err := r.inspector.DecodeQueryResults(queryCtx, timeoutCtxToDecode, results, time.Since(queryStart))
 
 	if err != nil {
 		log.Err(err)

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -133,22 +133,22 @@ func NewClient(params *Parameters, proBarBuilder *progress.PbBuilder, customPrin
 }
 
 // PerformScan executes executeScan and postScan
-func (c *Client) PerformScan(ctx context.Context) error {
+func (c *Client) PerformScan(ctx context.Context) (ScanMetadata, error) {
 	c.ScanStartTime = time.Now()
 
 	scanResults, err := c.executeScan(ctx)
 
 	if err != nil {
 		log.Err(err).Msgf("failed to execute scan %v", err)
-		return err
+		return ScanMetadata{}, err
 	}
 
-	postScanError := c.postScan(scanResults)
+	scanMetadata, postScanError := c.postScan(scanResults)
 
 	if postScanError != nil {
 		log.Err(postScanError)
-		return postScanError
+		return ScanMetadata{}, postScanError
 	}
 
-	return nil
+	return scanMetadata, nil
 }

--- a/pkg/scan/metadata.go
+++ b/pkg/scan/metadata.go
@@ -1,0 +1,45 @@
+package scan
+
+import (
+	"time"
+)
+
+type ScanMetadata struct {
+	// StartTime contains the instant in which the analysis started.
+	StartTime time.Time
+	// EndTime contains the instant in which the analysis ended.
+	EndTime time.Time
+	// DiffAware contains whether the analyzer could use Diff-Aware scanning.
+	DiffAware bool
+	// CoresAvailable contains the number of cores that were available to the analyzer.
+	CoresAvailable int
+	// Stats contains statistics about the analysis.
+	Stats ScanStats
+	// RuleStats contains statistics about rules.
+	RuleStats RuleStats
+}
+
+type ScanStats struct {
+	// Violations contains the number of violations that were found.
+	Violations int
+	// Files contains the number of files that were analyzed.
+	Files int
+	// Rules contains the number of rules that were evaluated.
+	Rules int
+	// Duration contains the time it took to complete the analysis.
+	Duration time.Duration
+}
+
+type RuleStats struct {
+	// TimedOut contains a list of rules that timed out.
+	TimedOut []string
+	// MostExpensiveRule contains the rule that spent the most time executing during the analysis.
+	MostExpensiveRule RuleTiming
+	// SlowestRule contains the rule that spent the most time executing per file.
+	SlowestRule RuleTiming
+}
+
+type RuleTiming struct {
+	Name string
+	Time time.Duration
+}

--- a/pkg/scan/post_scan_test.go
+++ b/pkg/scan/post_scan_test.go
@@ -330,7 +330,8 @@ func Test_resolveOutputs(t *testing.T) {
 			c.ScanParams = &tt.scanParams
 			c.ProBarBuilder = progress.InitializePbBuilder(true, false, true)
 			c.Printer = printer.NewPrinter(true)
-			err := c.postScan(tt.scanResults)
+			md, err := c.postScan(tt.scanResults)
+			require.NotNil(t, md)
 			require.NoError(t, err)
 		})
 	}

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Checkmarx/kics/internal/constants"
 	"github.com/Checkmarx/kics/internal/tracker"
@@ -200,7 +201,7 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) { //nolint
 	inspector, err := engine.NewInspector(
 		ctx,
 		queriesSource,
-		func(ctx *engine.QueryContext, trk engine.Tracker, v interface{}, detector *detector.DetectLine, useOldSeverities bool, kicsComputeNewSimID bool) (*model.Vulnerability, error) {
+		func(ctx *engine.QueryContext, trk engine.Tracker, v interface{}, detector *detector.DetectLine, useOldSeverities bool, kicsComputeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error) {
 			m, ok := v.(map[string]interface{})
 			require.True(t, ok)
 


### PR DESCRIPTION
We want to add some analyzer metadata about the run to the output from the KICS tool.