### PR TITLE
[K9VULN-2808] Set run type in SARIF

### DIFF
--- a/pkg/model/source_code.go
+++ b/pkg/model/source_code.go
@@ -7,6 +7,7 @@ package model
 
 type SCIInfo struct {
 	DiffAware DiffAware
+	RunType   string `json:"run_type"`
 }
 
 // DiffAware contains the necessary information to be able to perform a diff between two reports

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -230,6 +230,7 @@ type SarifReport interface {
 	GetGUIDFromRelationships(idx int, cweID string) string
 	AddTags(summary *model.Summary, diffAware *model.DiffAware) error
 	ResolveFilepaths(basePath string) error
+	SetToolVersionType(runType string)
 }
 
 type sarifReport struct {
@@ -694,6 +695,12 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult) string {
 		return issue.CWE
 	}
 	return ""
+}
+
+func (sr *sarifReport) SetToolVersionType(runType string) {
+	if len(runType) > 0 {
+		sr.Runs[0].Tool.Driver.ToolVersion = runType
+	}
 }
 
 func (sr *sarifReport) AddTags(summary *model.Summary, diffAware *model.DiffAware) error {

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -24,6 +24,7 @@ func PrintSarifReport(path, filename string, body interface{}, sciInfo model.SCI
 		}
 
 		sarifReport := reportModel.NewSarifReport()
+		sarifReport.SetToolVersionType(sciInfo.RunType)
 		auxID := []string{}
 		auxGUID := map[string]string{}
 		for idx := range summary.Queries {

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -67,6 +67,46 @@ func TestPrintSarifReport(t *testing.T) {
 	}
 }
 
+func TestPrintSarifReportWithToolVersionFullScan(t *testing.T) {
+	for idx, test := range sarifTests {
+		t.Run(fmt.Sprintf("Sarif File test case %d", idx), func(t *testing.T) {
+			if err := os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+			err := PrintSarifReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{RunType: "full_scan"})
+			checkFileExists(t, err, &test, "sarif")
+			jsonResult, err := os.ReadFile(filepath.Join(test.caseTest.path, test.caseTest.filename+".sarif"))
+			require.NoError(t, err)
+			var resultSarif sarifReport
+			err = json.Unmarshal(jsonResult, &resultSarif)
+			require.NoError(t, err)
+			require.Len(t, resultSarif.Runs, len(test.expectedResult.Queries))
+			require.Equal(t, resultSarif.Runs[0].Tool.Driver.ToolVersion, "full_scan")
+			os.RemoveAll(test.caseTest.path)
+		})
+	}
+}
+
+func TestPrintSarifReportWithToolVersionCodeUpdate(t *testing.T) {
+	for idx, test := range sarifTests {
+		t.Run(fmt.Sprintf("Sarif File test case %d", idx), func(t *testing.T) {
+			if err := os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+			err := PrintSarifReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{RunType: "code_update"})
+			checkFileExists(t, err, &test, "sarif")
+			jsonResult, err := os.ReadFile(filepath.Join(test.caseTest.path, test.caseTest.filename+".sarif"))
+			require.NoError(t, err)
+			var resultSarif sarifReport
+			err = json.Unmarshal(jsonResult, &resultSarif)
+			require.NoError(t, err)
+			require.Len(t, resultSarif.Runs, len(test.expectedResult.Queries))
+			require.Equal(t, resultSarif.Runs[0].Tool.Driver.ToolVersion, "code_update")
+			os.RemoveAll(test.caseTest.path)
+		})
+	}
+}
+
 func checkFileExists(t *testing.T, err error, tc *reportTestCase, extension string) {
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(tc.caseTest.path, tc.caseTest.filename+fmt.Sprintf(".%s", extension)))


### PR DESCRIPTION
We want to specify the run type- code update or full scan in the SARIF results so that we are able to filter on them downstream.