### PR TITLE
[K9VULN-2969] Add DATADOG_FINGERPRINT to SARIF results

### DIFF
--- a/pkg/model/source_code.go
+++ b/pkg/model/source_code.go
@@ -6,8 +6,9 @@
 package model
 
 type SCIInfo struct {
-	DiffAware DiffAware
-	RunType   string `json:"run_type"`
+	DiffAware            DiffAware
+	RunType              string               `json:"run_type"`
+	RepositoryCommitInfo RepositoryCommitInfo `json:"repository_commit_info"`
 }
 
 // DiffAware contains the necessary information to be able to perform a diff between two reports
@@ -16,4 +17,10 @@ type DiffAware struct {
 	ConfigDigest string `json:"config_digest"`
 	BaseSha      string `json:"base_sha"`
 	Files        string `json:"files"`
+}
+
+type RepositoryCommitInfo struct {
+	RepositoryUrl string `json:"repository_url,omitempty"`
+	Branch        string `json:"branch,omitempty"`
+	CommitSHA     string `json:"sha,omitempty"`
 }

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -107,6 +107,21 @@ var sarifTests = []sarifTest{
 							},
 							ResultLevel:      "error",
 							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:"}},
+							PartialFingerprints: SarifPartialFingerprints{
+								DatadogFingerprint: GetDatadogFingerprintHash(
+									model.SCIInfo{
+										RunType: "",
+										RepositoryCommitInfo: model.RepositoryCommitInfo{
+											RepositoryUrl: "",
+											Branch:        "",
+											CommitSHA:     "",
+										},
+									},
+									"test.json",
+									1,
+									"1",
+								),
+							},
 						},
 					},
 					Taxonomies: []sarifTaxonomy{
@@ -260,6 +275,21 @@ var sarifTests = []sarifTest{
 								},
 							},
 							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:test"}},
+							PartialFingerprints: SarifPartialFingerprints{
+								DatadogFingerprint: GetDatadogFingerprintHash(
+									model.SCIInfo{
+										RunType: "",
+										RepositoryCommitInfo: model.RepositoryCommitInfo{
+											RepositoryUrl: "",
+											Branch:        "",
+											CommitSHA:     "",
+										},
+									},
+									"",
+									1,
+									"test",
+								),
+							},
 						},
 						{
 							ResultRuleID:    "test info",
@@ -278,6 +308,21 @@ var sarifTests = []sarifTest{
 								},
 							},
 							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:test", "CWE:22"}},
+							PartialFingerprints: SarifPartialFingerprints{
+								DatadogFingerprint: GetDatadogFingerprintHash(
+									model.SCIInfo{
+										RunType: "",
+										RepositoryCommitInfo: model.RepositoryCommitInfo{
+											RepositoryUrl: "",
+											Branch:        "",
+											CommitSHA:     "",
+										},
+									},
+									"",
+									1,
+									"test info",
+								),
+							},
 						},
 					},
 					Taxonomies: []sarifTaxonomy{
@@ -330,13 +375,14 @@ func TestBuildSarifIssue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewSarifReport().(*sarifReport)
 			for _, vq := range tt.vq {
-				result.BuildSarifIssue(&vq)
+				result.BuildSarifIssue(&vq, model.SCIInfo{})
 			}
 			require.Equal(t, len(tt.want.Runs[0].Results), len(result.Runs[0].Results))
 			require.Equal(t, len(tt.want.Runs[0].Tool.Driver.Rules), len(result.Runs[0].Tool.Driver.Rules))
 			for index, wantResult := range tt.want.Runs[0].Results {
 				actualResult := result.Runs[0].Results[index]
 				require.Equal(t, wantResult.ResultProperties["tags"], actualResult.ResultProperties["tags"])
+				require.Equal(t, wantResult.PartialFingerprints.DatadogFingerprint, actualResult.PartialFingerprints.DatadogFingerprint)
 			}
 			if len(tt.want.Runs[0].Tool.Driver.Rules) > 0 {
 				if len(result.Runs[0].Tool.Driver.Rules[0].Relationships) > 0 {

--- a/pkg/report/model/utils.go
+++ b/pkg/report/model/utils.go
@@ -6,6 +6,8 @@
 package model
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/Checkmarx/kics/pkg/model"
@@ -48,4 +50,12 @@ func GetKICSRuleIDTag(ruleID string) string {
 
 func GetCWETag(cwe string) string {
 	return fmt.Sprintf(cweTag, cwe)
+}
+
+// stringToHash returns a SHA256 hash of the input string.
+func StringToHash(str string) string {
+	hash := sha256.New()
+	hash.Write([]byte(str))
+	hashed := hash.Sum(nil)
+	return hex.EncodeToString(hashed)
 }

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -27,7 +27,7 @@ func PrintSarifReport(path, filename string, body interface{}, sciInfo model.SCI
 		auxID := []string{}
 		auxGUID := map[string]string{}
 		for idx := range summary.Queries {
-			x := sarifReport.BuildSarifIssue(&summary.Queries[idx])
+			x := sarifReport.BuildSarifIssue(&summary.Queries[idx], sciInfo)
 			if x != "" {
 				auxID = append(auxID, x)
 				guid := sarifReport.GetGUIDFromRelationships(idx, x)


### PR DESCRIPTION
As part of ensuring unique results get processed correctly we want to handle full_repo scans vs code_update scans and ensure that the downstream processing correctly dedupes so that we don't inadvertently skip processing results because we think they are duplicates.
The logic here is that for full-repo we will tie the run date to ensure that we treat individual dates as unique results and for code-updates scope it to the commit sha.
