### PR TITLE
[K9VULN-2829] Modify rego query to check for aws_ resource types

### DIFF
--- a/assets/queries/terraform/aws/iam_access_analyzer_not_enabled/query.rego
+++ b/assets/queries/terraform/aws/iam_access_analyzer_not_enabled/query.rego
@@ -36,6 +36,7 @@ CxPolicy[result] {
 
 not_defined(document_indexes) {
 	count(document_indexes) != 0
+    count({type | input.document[x].resource[type]; startswith(type, "aws_")}) > 0
 	count({name | input.document[x].resource[name]; contains(name, "aws")}) > 0
 	count({x | resource := input.document[x].resource; common_lib.valid_key(resource, "aws_accessanalyzer_analyzer")}) == 0
 }


### PR DESCRIPTION
We seem to be flagging on non aws-resources for the `iam_access_analyzer_not_enabled` rule. 
From what I can tell this could be happening because there is an aws resource in the document file that is triggering but then because this resource contains `aws` in the name it is also being associated with the violation.