### PR TITLE
[K9VULN-3337] Add severity breakdown to returned scan metadata

### DIFF
--- a/pkg/scan/metadata.go
+++ b/pkg/scan/metadata.go
@@ -28,6 +28,8 @@ type ScanStats struct {
 	Rules int
 	// Duration contains the time it took to complete the analysis.
 	Duration time.Duration
+	// ViolationBreakdowns contains a breakdown of the violations by severity.
+	ViolationBreakdowns map[string]int
 }
 
 type RuleStats struct {

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -180,11 +180,24 @@ func (c *Client) generateMetadata(scanResults *Results, startTime time.Time, end
 }
 
 func (c *Client) generateStats(scanResults *Results, scanDuration time.Duration) ScanStats {
+	// iterate through scanResults and create a map of severity to count
+	violationBreakdowns := make(map[string]int)
+	severitySet := make(map[model.Severity]bool)
+	for _, sev := range model.AllSeverities {
+		severitySet[sev] = true
+	}
+	for _, vuln := range scanResults.Results {
+		if _, exists := severitySet[vuln.Severity]; exists {
+			violationBreakdowns[string(vuln.Severity)]++
+		}
+	}
+
 	return ScanStats{
-		Violations: len(scanResults.Results),
-		Files:      c.Tracker.FoundFiles,
-		Rules:      c.Tracker.ExecutedQueries,
-		Duration:   scanDuration,
+		Violations:          len(scanResults.Results),
+		Files:               c.Tracker.FoundFiles,
+		Rules:               c.Tracker.ExecutedQueries,
+		Duration:            scanDuration,
+		ViolationBreakdowns: violationBreakdowns,
 	}
 }
 


### PR DESCRIPTION
As part of production readiness we want to be able to report metrics on certain information including the breakdown of violations by severity.