### PR TITLE
[K9VULN-3337] Add rule ids to severity breakdowns

### DIFF
--- a/pkg/scan/metadata.go
+++ b/pkg/scan/metadata.go
@@ -29,7 +29,7 @@ type ScanStats struct {
 	// Duration contains the time it took to complete the analysis.
 	Duration time.Duration
 	// ViolationBreakdowns contains a breakdown of the violations by severity.
-	ViolationBreakdowns map[string]int
+	ViolationBreakdowns map[string][]string
 }
 
 type RuleStats struct {

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -181,14 +181,18 @@ func (c *Client) generateMetadata(scanResults *Results, startTime time.Time, end
 
 func (c *Client) generateStats(scanResults *Results, scanDuration time.Duration) ScanStats {
 	// iterate through scanResults and create a map of severity to count
-	violationBreakdowns := make(map[string]int)
+	violationBreakdowns := make(map[string][]string)
 	severitySet := make(map[model.Severity]bool)
 	for _, sev := range model.AllSeverities {
 		severitySet[sev] = true
 	}
 	for _, vuln := range scanResults.Results {
 		if _, exists := severitySet[vuln.Severity]; exists {
-			violationBreakdowns[string(vuln.Severity)]++
+			temp := []string{}
+			if _, exists := violationBreakdowns[string(vuln.Severity)]; exists {
+				temp = violationBreakdowns[string(vuln.Severity)]
+			}
+			violationBreakdowns[string(vuln.Severity)] = append(temp, vuln.QueryID)
 		}
 	}
 


### PR DESCRIPTION
We want to include the rule ids as part of the severity breakdown of the violations in the returned scan metadata.