### PR TITLE
[K9VULN-3372] Clean up rule logic for restrict_public_buckets

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
@@ -3,25 +3,6 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
-#default of restrict_public_buckets is false
-CxPolicy[result] {
-	pubACL := input.document[i].resource.aws_s3_bucket_public_access_block[name]
-	not common_lib.valid_key(pubACL, "restrict_public_buckets")
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
-		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].restrict_public_buckets", [name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",
-		"keyActualValue": "'restrict_public_buckets' is missing",
-		"searchLine": common_lib.build_search_line(["resource", "aws_s3_bucket_public_access_block", name], []),
-		"remediation": "restrict_public_buckets = true",
-		"remediationType": "addition",
-	}
-}
-
 CxPolicy[result] {
 	pubACL := input.document[i].resource.aws_s3_bucket_public_access_block[name]
 	pubACL.restrict_public_buckets == false

--- a/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/test/positive1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/test/positive1.tf
@@ -6,8 +6,8 @@ resource "aws_s3_bucket" "positive1" {
 resource "aws_s3_bucket_public_access_block" "positive2" {
   bucket = aws_s3_bucket.example.id
 
-  block_public_acls   = true
-  block_public_policy = true
+  block_public_acls       = true
+  block_public_policy     = true
   restrict_public_buckets = false
 }
 


### PR DESCRIPTION
We got some customer feedback that because restrict_public_buckets defaults to false we should ideally not flag it as a violation when it is not defined.
This removes the rego check that was enforcing that restrict_public_buckets be present AND false. We now only fail this rule if the value is explicitly set to true.