### PR TITLE
[K9VULN-3826] Add explicit logs for exclusions

### DIFF
--- a/kics.go
+++ b/kics.go
@@ -4,7 +4,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
 
-package main
+package kics
 
 import (
 	"path/filepath"
@@ -14,27 +14,6 @@ import (
 	"github.com/Checkmarx/kics/pkg/scan"
 	"github.com/rs/zerolog/log"
 )
-
-func main() {
-	inputPaths := []string{
-		// "/Users/bahar.shah/go/src/github.com/DataDog/innovation-week-cloud-to-tf/terraform/ami.tf",
-		"/Users/bahar.shah/dev/kics/assets/queries/terraform/aws/s3_bucket_without_versioning",
-		// "/Users/bahar.shah/dev/kics/assets/queries/terraform/aws/team_tag_not_present",
-	}
-	outputPath := "/Users/bahar.shah/go/src/github.com/DataDog/innovation-week-cloud-to-tf"
-	sci := model.SCIInfo{
-		DiffAware: model.DiffAware{
-			Enabled: false,
-		},
-		RunType: "code_update",
-		RepositoryCommitInfo: model.RepositoryCommitInfo{
-			RepositoryUrl: "github.com/blah",
-			Branch:        "main",
-			CommitSHA:     "1234567890",
-		},
-	}
-	ExecuteKICSScan(inputPaths, outputPath, sci)
-}
 
 func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string) {
 	params := scan.GetDefaultParameters()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -77,6 +77,7 @@ type Parser struct {
 	parsers    kindParser
 	extensions model.Extensions
 	Platform   []string
+	SCIInfo    model.SCIInfo
 }
 
 // ParsedDocument is a struct containing data retrieved from parsing

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -33,6 +33,7 @@ type Parser struct {
 	convertFunc       Converter
 	numOfRetries      int
 	terraformVarsPath string
+	sciInfo           model.SCIInfo
 }
 
 // NewDefault initializes a parser with Parser default values
@@ -47,6 +48,13 @@ func NewDefault() *Parser {
 func NewDefaultWithVarsPath(terraformVarsPath string) *Parser {
 	parser := NewDefault()
 	parser.terraformVarsPath = terraformVarsPath
+	return parser
+}
+
+func NewDefaultWithParams(terraformVarsPath string, sciInfo model.SCIInfo) *Parser {
+	parser := NewDefault()
+	parser.terraformVarsPath = terraformVarsPath
+	parser.sciInfo = sciInfo
 	return parser
 }
 
@@ -188,6 +196,18 @@ func (p *Parser) Parse(path string, content []byte) ([]model.Document, []int, er
 	if err != nil {
 		log.Err(err).Msg("failed to parse comments")
 	}
+
+	log.Info().Str(
+		"branch", p.sciInfo.RepositoryCommitInfo.Branch,
+	).Str(
+		"sha", p.sciInfo.RepositoryCommitInfo.CommitSHA,
+	).Str(
+		"repository", p.sciInfo.RepositoryCommitInfo.RepositoryUrl,
+	).Str(
+		"exclusion_source", "inline",
+	).Int(
+		"lines_excluded", len(ignore[model.IgnoreLine]),
+	).Int("blocks_excluded", len(ignore[model.IgnoreBlock])).Msg("Exclusions")
 
 	linesToIgnore := comment.GetIgnoreLines(ignore, file.Body.(*hclsyntax.Body))
 

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -207,7 +207,7 @@ func (p *Parser) Parse(path string, content []byte) ([]model.Document, []int, er
 		"exclusion_source", "inline",
 	).Int(
 		"lines_excluded", len(ignore[model.IgnoreLine]),
-	).Int("blocks_excluded", len(ignore[model.IgnoreBlock])).Msg("Exclusions")
+	).Int("blocks_excluded", len(ignore[model.IgnoreBlock])).Msg("Exclusions Info")
 
 	linesToIgnore := comment.GetIgnoreLines(ignore, file.Body.(*hclsyntax.Body))
 

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -56,6 +56,7 @@ type Parameters struct {
 	UseOldSeverities            bool
 	MaxResolverDepth            int
 	KicsComputeNewSimID         bool
+	PreAnalysisExcludePaths     []string
 	SCIInfo                     model.SCIInfo
 }
 

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -156,8 +156,8 @@ func (c *Client) postScan(scanResults *Results) (ScanMetadata, error) {
 		"repository", c.ScanParams.SCIInfo.RepositoryCommitInfo.RepositoryUrl,
 	).Str(
 		"exclusion_source", "config_file",
-	).Str(
-		"excluded_paths", strings.Join(c.ScanParams.PreAnalysisExcludePaths, ","),
+	).Int(
+		"excluded_paths", len(c.ScanParams.PreAnalysisExcludePaths),
 	).Int(
 		"excluded_categories", len(c.ScanParams.ExcludeCategories),
 	).Int(

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -148,9 +148,25 @@ func (c *Client) postScan(scanResults *Results) (ScanMetadata, error) {
 	scanDuration := endTime.Sub(c.ScanStartTime)
 	consolePrinter.PrintScanDuration(&logger, scanDuration)
 
-	// printVersionCheck(c.Printer, &summary)
-
-	// contributionAppeal(c.Printer, c.ScanParams.QueriesPath)
+	log.Info().Str(
+		"branch", c.ScanParams.SCIInfo.RepositoryCommitInfo.Branch,
+	).Str(
+		"sha", c.ScanParams.SCIInfo.RepositoryCommitInfo.CommitSHA,
+	).Str(
+		"repository", c.ScanParams.SCIInfo.RepositoryCommitInfo.RepositoryUrl,
+	).Str(
+		"exclusion_source", "config_file",
+	).Str(
+		"excluded_paths", strings.Join(c.ScanParams.PreAnalysisExcludePaths, ","),
+	).Int(
+		"excluded_categories", len(c.ScanParams.ExcludeCategories),
+	).Int(
+		"excluded_severities", len(c.ScanParams.ExcludeSeverities),
+	).Int(
+		"excluded_queries", len(c.ScanParams.ExcludeQueries),
+	).Int(
+		"excluded_results", len(c.ScanParams.ExcludeResults),
+	).Msg("Exclusions Info")
 
 	exitCode := consoleHelpers.ResultsExitCode(&summary)
 	if consoleHelpers.ShowError("results") && exitCode != 0 {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -258,7 +258,7 @@ func (c *Client) createService(
 	combinedParser, err := parser.NewBuilder().
 		// Add(&jsonParser.Parser{}).
 		Add(&yamlParser.Parser{}).
-		Add(terraformParser.NewDefaultWithVarsPath(c.ScanParams.TerraformVarsPath)).
+		Add(terraformParser.NewDefaultWithParams(c.ScanParams.TerraformVarsPath, c.ScanParams.SCIInfo)).
 		Add(&bicepParser.Parser{}).
 		Add(&protoParser.Parser{}).
 		Add(&buildahParser.Parser{}).

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -72,6 +72,7 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 	}
 
 	c.ScanParams.Platform = pathTypes.Types
+	c.ScanParams.PreAnalysisExcludePaths = c.ScanParams.ExcludePaths
 	c.ScanParams.ExcludePaths = pathTypes.Exc
 
 	return allPaths, nil


### PR DESCRIPTION
This pr adds some logs around exclusion usage within the IaC scanner. Specifically we log the various types of exclusions as well as some additional information like branch and repository.

To do this I also needed to pipe through some information as well as make other pieces of information retrievable in the path analysis/scan processing.