### PR TITLE
[K9VULN-3784] Use root path to properly find config file for exclusions

### DIFF
--- a/kics.go
+++ b/kics.go
@@ -16,7 +16,7 @@ import (
 )
 
 func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string) {
-	params := scan.GetDefaultParameters()
+	params := scan.GetDefaultParameters(outputPath)
 	params.Path = inputPaths
 	params.OutputPath = outputPath
 	params.SCIInfo = sciInfo

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -71,10 +71,10 @@ type Client struct {
 	ProBarBuilder     *progress.PbBuilder
 }
 
-func GetDefaultParameters() *Parameters {
+func GetDefaultParameters(rootPath string) *Parameters {
 
 	// check for config file and load in relevant params if present
-	configParams, err := initializeConfig()
+	configParams, err := initializeConfig(rootPath)
 	if err != nil {
 		log.Err(err).Msgf("failed to initialize config %v", err)
 		return nil

--- a/pkg/scan/pre_scan.go
+++ b/pkg/scan/pre_scan.go
@@ -30,7 +30,7 @@ func setupConfigFile() (bool, error) {
 	return false, nil
 }
 
-func initializeConfig() (ConfigParameters, error) {
+func initializeConfig(rootPath string) (ConfigParameters, error) {
 	log.Debug().Msg("console.initializeConfig()")
 
 	configParams := ConfigParameters{}
@@ -46,8 +46,9 @@ func initializeConfig() (ConfigParameters, error) {
 	if exit {
 		return configParams, nil
 	}
+	configPath := filepath.Join(rootPath, constants.DefaultConfigFilename)
 
-	base := filepath.Base(constants.DefaultConfigFilename)
+	base := filepath.Base(configPath)
 	v.SetConfigName(base)
 	v.AddConfigPath(filepath.Dir(base))
 	ext, err := consoleHelpers.FileAnalyzer(base)


### PR DESCRIPTION
With the way we download/clone the repository files for IaC scanning and the fact that we expect the config file to be located at the root of the repository we were previously assuming that KICS is being run in the same directory as the repository root. However we actually download the files to a tmp directory and then run KICS on that dir which means the KICS base dir and the repository base dir don't match up.

For config file exclusions we ONLY look at the base dir and so we aren't properly finding the config file.
This change now prepends the correct tmp dir to the path where we look for the config file to ensure we can properly identify it if it is present.