### PR TITLE
[K9VULN-3921] Add resources scanned to emitted metadata

### DIFF
--- a/assets/queries/terraform/aws/alb_listening_on_http/test/positive2.tf
+++ b/assets/queries/terraform/aws/alb_listening_on_http/test/positive2.tf
@@ -28,8 +28,8 @@ resource "aws_vpc" "vpc1" {
 }
 
 resource "aws_subnet" "subnet1" {
-  vpc_id = aws_vpc.vpc1.id
-  cidr_block = "10.10.10.0/24"
+  vpc_id               = aws_vpc.vpc1.id
+  cidr_block           = "10.10.10.0/24"
   availability_zone_id = data.aws_availability_zones.available.zone_ids[0]
   tags = {
     Name = "subnet1"
@@ -37,8 +37,8 @@ resource "aws_subnet" "subnet1" {
 }
 
 resource "aws_subnet" "subnet2" {
-  vpc_id = aws_vpc.vpc1.id
-  cidr_block = "10.10.11.0/24"
+  vpc_id               = aws_vpc.vpc1.id
+  cidr_block           = "10.10.11.0/24"
   availability_zone_id = data.aws_availability_zones.available.zone_ids[1]
 
   tags = {
@@ -47,17 +47,17 @@ resource "aws_subnet" "subnet2" {
 }
 
 resource "aws_lb" "test" {
-  name = "test123"
+  name               = "test123"
   load_balancer_type = "application"
-  subnets = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
-  internal = true
+  subnets            = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
+  internal           = true
 }
 
 resource "aws_lb_target_group" "test" {
-  port = 80
-  protocol = "HTTP"
+  port        = 80
+  protocol    = "HTTP"
   target_type = "instance"
-  vpc_id = aws_vpc.vpc1.id
+  vpc_id      = aws_vpc.vpc1.id
 }
 
 resource "aws_default_security_group" "dsg" {
@@ -66,7 +66,7 @@ resource "aws_default_security_group" "dsg" {
 
 resource "aws_lb_listener" "listener" {
   load_balancer_arn = aws_lb.test.arn
-  port = 80
+  port              = 80
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.test.arn
@@ -75,39 +75,39 @@ resource "aws_lb_listener" "listener" {
 
 resource "aws_lb_target_group_attachment" "attach1" {
   target_group_arn = aws_lb_target_group.test.arn
-  target_id = aws_instance.inst1.id
-  port = 80
+  target_id        = aws_instance.inst1.id
+  port             = 80
 }
 
 resource "aws_instance" "inst1" {
   vpc_security_group_ids = [aws_default_security_group.dsg.id]
-  subnet_id = aws_subnet.subnet1.id
-  ami = data.aws_ami.ubuntu.id
-  instance_type = "t3.micro"
+  subnet_id              = aws_subnet.subnet1.id
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t3.micro"
 }
 
 resource "aws_lb_target_group_attachment" "attach2" {
   target_group_arn = aws_lb_target_group.test.arn
-  target_id = aws_instance.inst2.id
-  port = 80
+  target_id        = aws_instance.inst2.id
+  port             = 80
 }
 
 resource "aws_instance" "inst2" {
   vpc_security_group_ids = [aws_default_security_group.dsg.id]
-  subnet_id = aws_subnet.subnet1.id
-  ami = data.aws_ami.ubuntu.id
-  instance_type = "t3.micro"
+  subnet_id              = aws_subnet.subnet1.id
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t3.micro"
 }
 
 resource "aws_lb_target_group_attachment" "attach3" {
   target_group_arn = aws_lb_target_group.test.arn
-  target_id = aws_instance.inst3.id
-  port = 80
+  target_id        = aws_instance.inst3.id
+  port             = 80
 }
 
 resource "aws_instance" "inst3" {
   vpc_security_group_ids = [aws_default_security_group.dsg.id]
-  subnet_id = aws_subnet.subnet1.id
-  ami = data.aws_ami.ubuntu.id
-  instance_type = "t3.micro"
+  subnet_id              = aws_subnet.subnet1.id
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t3.micro"
 }

--- a/assets/queries/terraform/azure/app_service_managed_identity_disabled/test/negative1.tf
+++ b/assets/queries/terraform/azure/app_service_managed_identity_disabled/test/negative1.tf
@@ -13,10 +13,6 @@ resource "azurerm_app_service" "negative1" {
     "SOME_KEY" = "some-value"
   }
 
-  auth_settings = {
-    enabled = true
-  }
-
   connection_string {
     name  = "Database"
     type  = "SQLServer"

--- a/assets/queries/terraform/azure/app_service_managed_identity_disabled/test/positive1.tf
+++ b/assets/queries/terraform/azure/app_service_managed_identity_disabled/test/positive1.tf
@@ -13,10 +13,6 @@ resource "azurerm_app_service" "positive1" {
     "SOME_KEY" = "some-value"
   }
 
-  auth_settings = {
-    enabled = true
-  }
-
   connection_string {
     name  = "Database"
     type  = "SQLServer"

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -38,6 +38,7 @@ type CITracker struct {
 	BagOfFilesParse       map[string]int
 	BagOfFilesFound       map[string]int
 	syncFileMutex         sync.Mutex
+	FoundResources        int
 }
 
 // NewTracker will create a new instance of a tracker with the number of lines to display in results output
@@ -145,4 +146,9 @@ func (c *CITracker) TrackFileParseCountLines(countLines int) {
 // TrackFileIgnoreCountLines - information about the lines ignored of the parsed files
 func (c *CITracker) TrackFileIgnoreCountLines(countLines int) {
 	c.IgnoreCountLines += countLines
+}
+
+// TrackResourceFoundCountLines - information about the resources of the scanned files
+func (c *CITracker) TrackFileFoundCountResources(countResources int) {
+	c.FoundResources += countResources
 }

--- a/internal/tracker/ci_test.go
+++ b/internal/tracker/ci_test.go
@@ -36,6 +36,7 @@ func TestCITracker(t *testing.T) {
 		ParsedCountLines      int
 		IgnoreCountLines      int
 		lines                 int
+		FoundResources        int
 	}
 	tests := []struct {
 		name   string
@@ -58,6 +59,7 @@ func TestCITracker(t *testing.T) {
 				ParsedCountLines:      1,
 				IgnoreCountLines:      4,
 				lines:                 3,
+				FoundResources:        5,
 			},
 		},
 	}
@@ -79,6 +81,7 @@ func TestCITracker(t *testing.T) {
 			lines:              tt.fields.lines,
 			BagOfFilesParse:    make(map[string]int),
 			BagOfFilesFound:    make(map[string]int),
+			FoundResources:     tt.fields.FoundResources,
 		}
 		t.Run(fmt.Sprintf(tt.name+"_LoadedQueries"), func(t *testing.T) {
 			c.TrackQueryLoad(1)
@@ -144,6 +147,10 @@ func TestCITracker(t *testing.T) {
 			if !reflect.DeepEqual(got, 3) {
 				t.Errorf("GetOutputLines() = %v, want = %v", got, 3)
 			}
+		})
+		t.Run(fmt.Sprintf(tt.name+"_TrackFoundCountResources"), func(t *testing.T) {
+			c.TrackFileFoundCountResources(5)
+			require.Equal(t, 5, c.FoundCountLines)
 		})
 	}
 }

--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -103,6 +103,11 @@ func (s *Service) resolverSink(
 		s.Tracker.TrackFileFoundCountLines(documents.CountLines)
 		s.Tracker.TrackFileParseCountLines(documents.CountLines - len(documents.IgnoreLines))
 		s.Tracker.TrackFileIgnoreCountLines(len(documents.IgnoreLines))
+
+		if kind == model.KindTerraform {
+			resourceCount := GetCountTerraformResources(rfile.Content)
+			s.Tracker.TrackFileFoundCountResources(resourceCount)
+		}
 	}
 	return resFiles.Excluded, nil
 }

--- a/pkg/kics/service.go
+++ b/pkg/kics/service.go
@@ -44,12 +44,14 @@ type Storage interface {
 // Tracker is the interface that wraps the basic methods: TrackFileFound and TrackFileParse
 // TrackFileFound should increment the number of files to be scanned
 // TrackFileParse should increment the number of files parsed successfully to be scanned
+// TrackFileFoundCountResources should increment the number of resources to be scanned
 type Tracker interface {
 	TrackFileFound(path string)
 	TrackFileParse(path string)
 	TrackFileFoundCountLines(countLines int)
 	TrackFileParseCountLines(countLines int)
 	TrackFileIgnoreCountLines(countLines int)
+	TrackFileFoundCountResources(countResources int)
 }
 
 // Service is a struct that contains a SourceProvider to receive sources, a storage to save and retrieve scanning informations
@@ -133,9 +135,10 @@ func (s *Service) StartScan(
 
 // Content keeps the content of the file and the number of lines
 type Content struct {
-	Content    *[]byte
-	CountLines int
-	IsMinified bool
+	Content        *[]byte
+	CountLines     int
+	IsMinified     bool
+	CountResources int
 }
 
 /*
@@ -169,6 +172,7 @@ func getContent(rc io.Reader, data []byte, maxSizeMB int, filename string) (*Con
 	}
 	c.Content = &content
 	c.CountLines = countLines
+	c.CountResources = GetCountTerraformResources(content)
 
 	c.IsMinified = minified.IsMinified(filename, content)
 	return c, nil

--- a/pkg/kics/sink.go
+++ b/pkg/kics/sink.go
@@ -41,6 +41,7 @@ func (s *Service) sink(ctx context.Context, filename, scanID string,
 	content := c.Content
 
 	s.Tracker.TrackFileFoundCountLines(c.CountLines)
+	s.Tracker.TrackFileFoundCountResources(c.CountResources)
 
 	if err != nil {
 		return errors.Wrapf(err, "failed to get file content: %s", filename)

--- a/pkg/kics/terraform_utils.go
+++ b/pkg/kics/terraform_utils.go
@@ -1,0 +1,10 @@
+package kics
+
+import "regexp"
+
+func GetCountTerraformResources(fileContent []byte) int {
+	re := regexp.MustCompile(`\bresource\s+"[^"]+"\s+"[^"]+"\s*\{`)
+	matches := re.FindAll(fileContent, -1)
+
+	return len(matches)
+}

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -83,6 +83,7 @@ type Counters struct {
 	TotalQueries           int `json:"queries_total"`
 	FailedToExecuteQueries int `json:"queries_failed_to_execute"`
 	FailedSimilarityID     int `json:"queries_failed_to_compute_similarity_id"`
+	FoundResources         int `json:"resources_found"`
 }
 
 // Times represents an object that contains the start and end time of the scan

--- a/pkg/scan/metadata.go
+++ b/pkg/scan/metadata.go
@@ -30,6 +30,8 @@ type ScanStats struct {
 	Duration time.Duration
 	// ViolationBreakdowns contains a breakdown of the violations by severity.
 	ViolationBreakdowns map[string][]string
+	// ResourcesFound contains the number of resources that were analyzed.
+	ResourcesScanned int
 }
 
 type RuleStats struct {

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -32,6 +32,7 @@ func (c *Client) getSummary(results []model.Vulnerability, end time.Time, pathPa
 		TotalQueries:           c.Tracker.LoadedQueries,
 		FailedToExecuteQueries: c.Tracker.ExecutingQueries - c.Tracker.ExecutedQueries,
 		FailedSimilarityID:     c.Tracker.FailedSimilarityID,
+		FoundResources:         c.Tracker.FoundResources,
 	}
 
 	summary := model.CreateSummary(
@@ -220,6 +221,7 @@ func (c *Client) generateStats(scanResults *Results, scanDuration time.Duration)
 		Rules:               c.Tracker.ExecutedQueries,
 		Duration:            scanDuration,
 		ViolationBreakdowns: violationBreakdowns,
+		ResourcesScanned:    c.Tracker.FoundResources,
 	}
 }
 

--- a/pkg/scan/post_scan_test.go
+++ b/pkg/scan/post_scan_test.go
@@ -421,7 +421,7 @@ func Test_GetScanMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Client{}
 			c.Tracker = &tt.tracker
-			c.ScanParams = GetDefaultParameters()
+			c.ScanParams = GetDefaultParameters(".")
 			v := c.generateMetadata(tt.results, tt.scanStartTime, tt.endTime)
 
 			require.Equal(t, tt.expectedMetadata.StartTime, v.StartTime)


### PR DESCRIPTION
For tracking purposes it is helpful to keep track of all the Terraform resources found/scanned in the files of each run.
This PR does the work necessary to count the resources as the files are being processed and wire the count metadata in the various places needed to eventually surface it back to the invoking caller in dd-source.

Note for reviewers: There were a few formatting issues/linting errors I found during this PR so they are included in this changeset as well.