### PR TITLE
[K9VULN-4000] Add missing cloud-tf-ci rules for coverage

### DIFF
--- a/assets/generator/directory/main.go
+++ b/assets/generator/directory/main.go
@@ -29,8 +29,16 @@ func getInput(prompt, defaultValue string) string {
 }
 
 func main() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Printf("Failed to get home directory: %v \n", err)
+		os.Exit(1)
+	}
+
+	// Construct the full path: ~/dev/kics
+	defaultRepoPath := filepath.Join(homeDir, "dev", "kics")
+
 	// Set default values
-	defaultRepoPath := "~/dev/kics"
 	defaultPlatform := "terraform"
 	defaultProvider := "aws"
 

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/metadata.json
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/metadata.json
@@ -1,0 +1,12 @@
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "descriptionID": "550e8400",
+  "queryName": "Ensure legacy networks do not exist for a project",
+  "severity": "HIGH",
+  "category": "Networking",
+  "descriptionText": "Ensures that no legacy networks with auto_create_subnetworks enabled exist in a project.",
+  "descriptionUrl": "https://cloud.google.com/vpc/docs/vpc#legacy",
+  "platform": "Terraform",
+  "cloudProvider": "GCP",
+  "cwe": "CWE-400"
+}

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/metadata.json
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/metadata.json
@@ -5,7 +5,7 @@
   "severity": "HIGH",
   "category": "Networking",
   "descriptionText": "Ensures that no legacy networks with auto_create_subnetworks enabled exist in a project.",
-  "descriptionUrl": "https://cloud.google.com/vpc/docs/vpc#legacy",
+  "descriptionUrl": "https://cloud.google.com/vpc/docs/legacy",
   "platform": "Terraform",
   "cloudProvider": "GCP",
   "cwe": "CWE-400"

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/query.rego
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+CxPolicy[result] {
+    resource := input.document[i].resource.google_compute_network[name]
+    resource.auto_create_subnetworks == true
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": "google_compute_network",
+        "resourceName": tf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("google_compute_network[%s].auto_create_subnetworks", [name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "auto_create_subnetworks should be false",
+        "keyActualValue": "auto_create_subnetworks is true",
+        "searchLine": common_lib.build_search_line(["resource", "google_compute_network", name],["auto_create_subnetworks"]),
+        "remediation": json.marshal({
+            "before": "true",
+            "after": "false"
+        }),
+        "remediationType": "replacement",
+    }
+}

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/negative.tf
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/negative.tf
@@ -1,0 +1,4 @@
+resource "google_compute_network" "modern_network" {
+  name                    = "modern-network"
+  auto_create_subnetworks = false
+}

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/negative_2.tf
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/negative_2.tf
@@ -1,0 +1,3 @@
+resource "google_compute_network" "legacy_network_2" {
+  name = "legacy-network"
+}

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/positive.tf
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/positive.tf
@@ -1,0 +1,4 @@
+resource "google_compute_network" "legacy_network" {
+  name                    = "legacy-network"
+  auto_create_subnetworks = true
+}

--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Ensure legacy networks do not exist for a project",
+    "severity": "HIGH",
+    "line": 3
+  }
+]

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/metadata.json
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/metadata.json
@@ -1,0 +1,12 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "descriptionID": "a1b2c3d4",
+  "queryName": "There are non GCP-managed service account keys for a service account",
+  "severity": "HIGH",
+  "category": "ENCRYPTION",
+  "descriptionText": "Ensures that only GCP-managed service account keys are used, preventing manually created keys that pose security risks.",
+  "descriptionUrl": "https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys",
+  "platform": "Terraform",
+  "cloudProvider": "GCP",
+  "cwe": "CWE-522"
+}

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/query.rego
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+CxPolicy[result] {
+    resource := input.document[i].resource.google_service_account_key[name]
+    common_lib.valid_key(resource, "public_key_data")
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": "google_service_account_key",
+        "resourceName": tf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("google_service_account_key[%s].public_key_data", [name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "google_service_account_key should not have a public_key_data attribute",
+        "keyActualValue": "google_service_account_key has a public_key_data attribute",
+        "searchLine": common_lib.build_search_line(["resource", "google_service_account_key", name],["public_key_data"]),
+        "remediation": "Remove the google_service_account_key resource to rely only on GCP-managed keys.",
+        "remediationType": "removal",
+    }
+}

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/test/negative.tf
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/test/negative.tf
@@ -1,0 +1,3 @@
+resource "google_service_account_key" "bad_key" {
+  service_account_id = "projects/my-project/serviceAccounts/my-service-account"
+}

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/test/positive.tf
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/test/positive.tf
@@ -1,0 +1,4 @@
+resource "google_service_account_key" "bad_key" {
+  service_account_id = "projects/my-project/serviceAccounts/my-service-account"
+  public_key_data    = "dummy-key"
+}

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Ensure that there are only GCP-managed service account keys for each service account",
+    "severity": "HIGH",
+    "line": 3
+  }
+]

--- a/dd-iac-scan.config
+++ b/dd-iac-scan.config
@@ -1,3 +1,3 @@
 {
-  "exclude-severities":[low],
+  "exclude-severities":[low, info],
 }


### PR DESCRIPTION
As part of continuing to match coverage with the internal usage of Checkov at Datadog this PR adds the rules identified as missing from the current implementation of Checkov happening in [cloud-tf-ci](https://github.com/DataDog/cloud-tf-ci/blob/a8820543fd4aaad74baf79927150560445bfd13f/src/tools/job/checkov-config.yml).
There are [2 rules](https://docs.google.com/spreadsheets/d/1exbE0FBv9LTNS9Vylbm8xCBlX9A2zq5saXkX7RNw83I/edit?gid=517370387#gid=517370387) missing which this PR adds coverage for.

Checkov ID | Rule Description | KICS ID | KICS Rule Description
-- | -- | -- | --
CKV2_GCP_2 | Ensure legacy networks do not exist for a project | 550e8400-e29b-41d4-a716-446655440000 | Ensure legacy networks do not exist for a project
CKV2_GCP_3 | Ensure that there are only GCP-managed service account keys for each service account | a1b2c3d4-e5f6-7890-abcd-ef1234567890 | There are non GCP-managed service account keys for a service account

