### PR TITLE
[K9VULN-4043] Add resource name and resource type to SARIF results

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -647,7 +647,16 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 			if line < 1 {
 				line = 1
 			}
-			resourceLocation := issue.Files[idx].ResourceLocation
+			vulnerability := issue.Files[idx]
+
+			resourceType := vulnerability.ResourceType
+			resourceName := vulnerability.ResourceName
+			resourceTypeTag := GetResourceTypeTag(resourceType)
+			resourceNameTag := GetResourceNameTag(resourceName)
+
+			resultTags := append(tags, resourceTypeTag, resourceNameTag)
+
+			resourceLocation := vulnerability.ResourceLocation
 			startLocation := sarifResourceLocation{
 				Line: resourceLocation.ResourceStart.Line,
 				Col:  resourceLocation.ResourceStart.Col,
@@ -688,7 +697,7 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 					},
 				},
 				ResultProperties: sarifProperties{
-					"tags": tags,
+					"tags": resultTags,
 				},
 				PartialFingerprints: SarifPartialFingerprints{
 					DatadogFingerprint: GetDatadogFingerprintHash(sciInfo, absoluteFilePath, line, issue.QueryID),

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -54,7 +54,7 @@ var sarifTests = []sarifTest{
 				QueryURI:    "https://www.test.com",
 				Severity:    model.SeverityHigh,
 				Files: []model.VulnerableFile{
-					{KeyActualValue: "test", FileName: "test.json", Line: -1},
+					{KeyActualValue: "test", FileName: "test.json", Line: -1, ResourceType: "test_resource_type", ResourceName: "test_resource_name"},
 				},
 				CWE: "",
 			},
@@ -106,7 +106,7 @@ var sarifTests = []sarifTest{
 								},
 							},
 							ResultLevel:      "error",
-							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:"}},
+							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:", "IAC_RESOURCE_TYPE:test_resource_type", "IAC_RESOURCE_NAME:test_resource_name"}},
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
@@ -172,7 +172,7 @@ var sarifTests = []sarifTest{
 				Category:    "test",
 				Severity:    model.SeverityHigh,
 				Files: []model.VulnerableFile{
-					{KeyActualValue: "test", FileName: "", Line: 1},
+					{KeyActualValue: "test", FileName: "", Line: 1, ResourceType: "test_resource_type", ResourceName: "test_resource_name"},
 				},
 				CWE: "",
 			},
@@ -184,7 +184,7 @@ var sarifTests = []sarifTest{
 				Category:    "test",
 				Severity:    model.SeverityInfo,
 				Files: []model.VulnerableFile{
-					{KeyActualValue: "test", FileName: "", Line: 1},
+					{KeyActualValue: "test", FileName: "", Line: 1, ResourceType: "test_resource_type_2", ResourceName: "test_resource_name_2"},
 				},
 				CWE: "22",
 			},
@@ -274,7 +274,7 @@ var sarifTests = []sarifTest{
 									},
 								},
 							},
-							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:test"}},
+							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:test", "IAC_RESOURCE_TYPE:test_resource_type", "IAC_RESOURCE_NAME:test_resource_name"}},
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
@@ -307,7 +307,7 @@ var sarifTests = []sarifTest{
 									},
 								},
 							},
-							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:test", "CWE:22"}},
+							ResultProperties: sarifProperties{"tags": []string{"DATADOG_CATEGORY:test", "CWE:22", "IAC_RESOURCE_TYPE:test_resource_type_2", "IAC_RESOURCE_NAME:test_resource_name_2"}},
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{

--- a/pkg/report/model/utils.go
+++ b/pkg/report/model/utils.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	kicsRuleIDTag = "KICS_RuleID:%s"
-	cweTag        = "CWE:%s"
+	kicsRuleIDTag   = "KICS_RuleID:%s"
+	cweTag          = "CWE:%s"
+	resourceTypeTag = "IAC_RESOURCE_TYPE:%s"
+	resourceNameTag = "IAC_RESOURCE_NAME:%s"
 )
 
 func GetScanDurationTag(summary model.Summary) string {
@@ -50,6 +52,14 @@ func GetKICSRuleIDTag(ruleID string) string {
 
 func GetCWETag(cwe string) string {
 	return fmt.Sprintf(cweTag, cwe)
+}
+
+func GetResourceTypeTag(resourceType string) string {
+	return fmt.Sprintf(resourceTypeTag, resourceType)
+}
+
+func GetResourceNameTag(resourceName string) string {
+	return fmt.Sprintf(resourceNameTag, resourceName)
 }
 
 // stringToHash returns a SHA256 hash of the input string.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,9 +20,9 @@ func Test_E2EExclusions(t *testing.T) {
 			name:     "no exclusions",
 			testFile: filepath.Join("fixtures", "no-exclusions.tf"),
 			expectedOutput: scan.ScanStats{
-				Violations: 5,
+				Violations: 6,
 				Files:      1,
-				Rules:      1088,
+				Rules:      1126,
 				ViolationBreakdowns: map[string][]string{
 					"LOW":    {"c5b31ab9-0f26-4a49-b8aa-4cc064392f4d", "e592a0c5-5bdb-414c-9066-5dba7cdea370", "c5b31ab9-0f26-4a49-b8aa-4cc064392f4d"},
 					"MEDIUM": {"f861041c-8c9f-4156-acfc-5e6e524f5884", "568a4d22-3517-44a6-a7ad-6a7eed88722c"},
@@ -33,9 +33,9 @@ func Test_E2EExclusions(t *testing.T) {
 			name:     "disabled rule inline",
 			testFile: filepath.Join("fixtures", "inline-disabled-rule.tf"),
 			expectedOutput: scan.ScanStats{
-				Violations: 4,
+				Violations: 5,
 				Files:      1,
-				Rules:      1088,
+				Rules:      1126,
 				ViolationBreakdowns: map[string][]string{
 					"LOW":    {"c5b31ab9-0f26-4a49-b8aa-4cc064392f4d", "c5b31ab9-0f26-4a49-b8aa-4cc064392f4d"},
 					"MEDIUM": {"f861041c-8c9f-4156-acfc-5e6e524f5884", "568a4d22-3517-44a6-a7ad-6a7eed88722c"},


### PR DESCRIPTION
We received feedback from Kobold and Org2 that it would be nice to filter and view results based on resource type and resource name. 

In order to do this we need to enrich the SARIF file produced with these details for each result and then process and parse in the SARIF processing.

This PR adds the attributes to the SARIF file.