### PR TITLE
[K9VULN-3905] Address reported false positive in 12944ec4-1fa0-47be-8b17-42a034f937c2 and duplicated rule ids

### DIFF
--- a/assets/queries/terraform/aws/iam_password_does_not_require_uppercase/metadata.json
+++ b/assets/queries/terraform/aws/iam_password_does_not_require_uppercase/metadata.json
@@ -1,12 +1,12 @@
 {
-  "id": "a1b2c3d4-e5f6-7890-ab12-cd34ef567890",
+  "id": "2c3d4ghwt-e5f6-7890-ab12-cd34ef567890",
   "queryName": "IAM Password Policy Does Not Require Uppercase Letter",
   "severity": "MEDIUM",
   "category": "Best Practices",
   "descriptionText": "Ensures that the AWS IAM password policy requires at least one uppercase letter. Without this setting, passwords may be easier to guess, leading to security vulnerabilities.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy#require_uppercase_characters",
   "platform": "Terraform",
-  "descriptionID": "a1b2c3d",
+  "descriptionID": "2c3d4ghwt",
   "cloudProvider": "aws",
   "cwe": "521"
 }

--- a/assets/queries/terraform/azure/postgres_enforce_ssl_connection_disabled/metadata.json
+++ b/assets/queries/terraform/azure/postgres_enforce_ssl_connection_disabled/metadata.json
@@ -1,12 +1,12 @@
 {
-  "id": "a1b2c3d4-e5f6-7890-ab12-cd34ef567890",
+  "id": "93f9tyjk-e5f6-7890-ab12-cd34ef567890",
   "queryName": "'ssl_enforcement_enabled' is not set to 'ENABLED' for PostgreSQL Database Server",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "PostgreSQL Database Server should have SSL enforcement enabled to ensure secure connections. The 'ssl_enforcement_enabled' attribute must be set to 'ENABLED'.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_server",
   "platform": "Terraform",
-  "descriptionID": "a1b2c3d4",
+  "descriptionID": "93f9tyjk",
   "cloudProvider": "azure",
   "cwe": "311"
 }

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/metadata.json
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/metadata.json
@@ -4,7 +4,7 @@
   "severity": "MEDIUM",
   "category": "Encryption",
   "descriptionText": "Storage Accounts should enforce the use of HTTPS",
-  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#https_traffic_only_enabled-1",
   "platform": "Terraform",
   "descriptionID": "ab6688ca",
   "cloudProvider": "azure",

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/query.rego
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/query.rego
@@ -5,35 +5,17 @@ import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_storage_account[var0]
-	not common_lib.valid_key(resource, "enable_https_traffic_only")
+	resource.https_traffic_only_enabled == false
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "azurerm_storage_account",
 		"resourceName": tf_lib.get_resource_name(resource, var0),
-		"searchKey": sprintf("azurerm_storage_account[%s]", [var0]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' equals 'true'", [var0]),
-		"keyActualValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' does not exist", [var0]),
-		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "enable_https_traffic_only" ], []),
-		"remediation": "enable_https_traffic_only = true",
-		"remediationType": "addition",
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.azurerm_storage_account[var0]
-	resource.enable_https_traffic_only == false
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "azurerm_storage_account",
-		"resourceName": tf_lib.get_resource_name(resource, var0),
-		"searchKey": sprintf("azurerm_storage_account[%s].enable_https_traffic_only", [var0]),
+		"searchKey": sprintf("azurerm_storage_account[%s].https_traffic_only_enabled", [var0]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' equals 'true'", [var0]),
-		"keyActualValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' equals 'false'", [var0]),
-		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "enable_https_traffic_only" ], []),
+		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.https_traffic_only_enabled' equals 'true'", [var0]),
+		"keyActualValue": sprintf("'azurerm_storage_account.%s.https_traffic_only_enabled' equals 'false'", [var0]),
+		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "https_traffic_only_enabled" ], []),
 		"remediation": json.marshal({
 			"before": "false",
 			"after": "true"

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/negative.tf
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/negative.tf
@@ -1,8 +1,8 @@
 resource "azurerm_storage_account" "negative1" {
-  name                      = "example"
-  resource_group_name       = data.azurerm_resource_group.example.name
-  location                  = data.azurerm_resource_group.example.location
-  account_tier              = "Standard"
-  account_replication_type  = "GRS"
-  enable_https_traffic_only = true
+  name                       = "example"
+  resource_group_name        = data.azurerm_resource_group.example.name
+  location                   = data.azurerm_resource_group.example.location
+  account_tier               = "Standard"
+  account_replication_type   = "GRS"
+  https_traffic_only_enabled = true # Set to true as desired
 }

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/negative1.tf
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/negative1.tf
@@ -1,0 +1,9 @@
+resource "azurerm_storage_account" "positive2" {
+  name                     = "example2"
+  resource_group_name      = data.azurerm_resource_group.example.name
+  location                 = data.azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  # will not flag because https_traffic_only_enabled is set to true by default so we do not error
+}

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive.tf
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive.tf
@@ -1,16 +1,8 @@
 resource "azurerm_storage_account" "positive1" {
-  name                      = "example1"
-  resource_group_name       = data.azurerm_resource_group.example.name
-  location                  = data.azurerm_resource_group.example.location
-  account_tier              = "Standard"
-  account_replication_type  = "GRS"
-  enable_https_traffic_only = false
-}
-
-resource "azurerm_storage_account" "positive2" {
-  name                      = "example2"
-  resource_group_name       = data.azurerm_resource_group.example.name
-  location                  = data.azurerm_resource_group.example.location
-  account_tier              = "Standard"
-  account_replication_type  = "GRS"
+  name                       = "example1"
+  resource_group_name        = data.azurerm_resource_group.example.name
+  location                   = data.azurerm_resource_group.example.location
+  account_tier               = "Standard"
+  account_replication_type   = "GRS"
+  https_traffic_only_enabled = false
 }

--- a/assets/queries/terraform/gcp/pubsub_topic_is_public/metadata.json
+++ b/assets/queries/terraform/gcp/pubsub_topic_is_public/metadata.json
@@ -1,11 +1,11 @@
 {
-  "id": "25d251f3-f348-4f95-845c-1090e41a615c",
+  "id": "7sdj7dsj8-f348-4f95-845c-1090e41a615c",
   "queryName": "Pub/Sub Topics are anonymously or publicly accessible",
   "severity": "MEDIUM",
   "category": "Insecure Configurations",
   "descriptionText": "Pub/Sub Topics must not be publicly accessible. IAM members or bindings should not use 'allUsers' or 'allAuthenticatedUsers'.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member",
   "platform": "Terraform",
-  "descriptionID": "25d251f3",
+  "descriptionID": "7sdj7dsj8",
   "cloudProvider": "gcp"
 }

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/metadata.json
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/metadata.json
@@ -1,6 +1,6 @@
 {
-  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "descriptionID": "a1b2c3d4",
+  "id": "3jh54js8-e5f6-7890-abcd-ef1234567890",
+  "descriptionID": "3jh54js8",
   "queryName": "There are non GCP-managed service account keys for a service account",
   "severity": "HIGH",
   "category": "Encryption",


### PR DESCRIPTION
Customer reported that the rule appears to be using an outdated Terraform attribute. This PR updates the rule to check for the correct attribute. Because it defaults to true we also remove the check for missing attribute.

As part of pulling the current ruleset I noticed we have some duplicated rule ids so also cleaning those up.