### PR TITLE
[K9VULN-3999] Remove unused attributes from SARIF to help reduce size of file

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -171,7 +171,7 @@ type sarifLocation struct {
 type sarifResult struct {
 	ResultRuleID        string                   `json:"ruleId"`
 	ResultRuleIndex     int                      `json:"ruleIndex"`
-	ResultKind          string                   `json:"kind"`
+	ResultKind          string                   `json:"kind,omitempty"`
 	ResultMessage       sarifMessage             `json:"message"`
 	ResultLocations     []sarifLocation          `json:"locations"`
 	PartialFingerprints SarifPartialFingerprints `json:"partialFingerprints,omitempty"`
@@ -629,11 +629,6 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 		}
 		ruleIndex := sr.buildSarifRule(&metadata, cisDescriptions)
 
-		kind := "fail"
-		if severityLevelEquivalence[issue.Severity] == "none" {
-			kind = "informational"
-		}
-
 		categoryTag := GetCategoryTag(issue.Category)
 		tags := []string{categoryTag}
 		cwe := issue.CWE
@@ -673,13 +668,9 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 			result := sarifResult{
 				ResultRuleID:    issue.QueryName,
 				ResultRuleIndex: ruleIndex,
-				ResultKind:      kind,
 				ResultLevel:     severityLevelEquivalence[issue.Severity],
 				ResultMessage: sarifMessage{
 					Text: issue.Files[idx].KeyActualValue,
-					MessageProperties: sarifProperties{
-						"platform": issue.Platform,
-					},
 				},
 				ResultLocations: []sarifLocation{
 					{


### PR DESCRIPTION
As part of reducing the size of the SARIF file we generate there are a few attributes currently written which are not needed.

- Result Kind
    - This is used in KICS to denote failures vs informational traces but is not used within the ci-sarif-processor at all
- Result Message -> Platform
    - This is used in KICS to identify which IaC platform the result is part of. Because we are focusing on Terraform specifically this is not needed. Additionally the processing pipeline also parses out the file type so we already have another way of associating these results to Terraform