### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive4.tf
@@ -11,3 +11,4 @@ module "s3_bucket" {
   }
 
 }
+block_public_acls = true


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Allows Public ACL](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/b73e457512f2df6fc86ac9f6b0583a28d36596a8/iac-vulnerabilities?staticAnalysisId=AwAAAZY6MZsR9KSrsgAAABhBWlk2TVpTckFBQTJBOHhfNFpybkFBQUEAAAAkMDE5NjNhMzEtYTYwYi00ZDMzLThlY2UtOWVkMmMwYzEwYTgwAABRdg)