### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive6.tf
@@ -6,4 +6,5 @@ module "s3_bucket" {
   bucket = "my-s3-bucket"
   acl    = "private"
 
-}
+
+block_public_acls = true}

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -806,6 +806,8 @@ func GetDatadogFingerprintHash(sciInfo model.SCIInfo, filePath string, startLine
 
 func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceLocation, endLocation sarifResourceLocation) (sarifFix, error) {
 	var insertedText string
+	fixStart := startLocation
+	fixEnd := endLocation
 
 	switch vuln.RemediationType {
 	case "replacement":
@@ -845,7 +847,11 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceL
 		insertedText = prefix + after + suffix
 
 	case "addition":
-		insertedText = vuln.Remediation
+		insertedText = fmt.Sprintf("\n%s", vuln.Remediation)
+		fixStart = sarifResourceLocation{
+			Line: fixEnd.Line,
+			Col:  fixEnd.Col,
+		}
 
 	case "removal":
 		insertedText = "" // no content to insert
@@ -853,10 +859,10 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceL
 
 	replacement := fixReplacement{
 		DeletedRegion: sarifRegion{
-			StartLine:   startLocation.Line,
-			StartColumn: startLocation.Col,
-			EndLine:     endLocation.Line,
-			EndColumn:   endLocation.Col,
+			StartLine:   fixStart.Line,
+			StartColumn: fixStart.Col,
+			EndLine:     fixEnd.Line,
+			EndColumn:   fixEnd.Col,
 		},
 	}
 

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -849,8 +849,12 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceL
 	case "addition":
 		insertedText = fmt.Sprintf("\n%s", vuln.Remediation)
 		fixStart = sarifResourceLocation{
+			Line: fixEnd.Line, // we want to insert right before the closing brace
+			Col:  1,
+		}
+		fixEnd = sarifResourceLocation{
 			Line: fixEnd.Line,
-			Col:  fixEnd.Col,
+			Col:  1,
 		}
 
 	case "removal":


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Allows Public ACL](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/55af2a009896817048befda3b13d82e10e355928/iac-vulnerabilities?staticAnalysisId=AwAAAZY6OvxhugNbAgAAABhBWlk2T3ZJMkFBQkpWakFIaGc5dUFBQUEAAAAkMDE5NjNhM2EtZmM2MS00MTYzLWJhZDAtMTFkMjAyZTllMzVmAAABGQ)