### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive5.tf
@@ -10,4 +10,6 @@ module "s3_bucket" {
     mfa_delete = true
   }
 
+
+  ignore_public_acls = true
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Without Ignore Public ACL](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/d80d50425bfcd02ce353427f5213f31104b96245/iac-vulnerabilities?staticAnalysisId=AwAAAZY6f5smo5cz7AAAABhBWlk2ZnBnY0FBQW5WYm1WR205b0FBQUEAAAAkMDE5NjNhN2YtOWIyNi00OTE0LWI2NjgtOWUyNGE2YjJmODU3AAAABQ)