### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive4.tf
@@ -10,4 +10,6 @@ module "s3_bucket" {
     enabled = false
   }
 
+
+  ignore_public_acls = true
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Without Ignore Public ACL](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/3bfec9abc597b57f8a9d1a0b939b3721b4e1b720/iac-vulnerabilities?staticAnalysisId=AwAAAZY6mgPsrHvjnQAAABhBWlk2bWZ0M0FBQW1fbmV3X0lkbkFBQUEAAAAkMDE5NjNhOWEtMjhhZS00NWZjLTkwOWQtODcxMTAyZjlkNDY0AACQZw)