### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive5.tf
@@ -6,6 +6,8 @@ module "s3_bucket" {
   bucket = "my-s3-bucket"
   acl    = "private"
 
+
+  enabled = true
   versioning = {
     mfa_delete = true
   }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Without Versioning](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/3bfec9abc597b57f8a9d1a0b939b3721b4e1b720/iac-vulnerabilities?staticAnalysisId=AwAAAZY6mgPsrHvjiwAAABhBWlk2bWZ0M0FBQmkxLVpGU196dUFBQUEAAAAkMDE5NjNhOWEtMjhhZS00NWZjLTkwOWQtODcxMTAyZjlkNDY0AACQaQ)