### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/negative2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/negative2.tf
@@ -10,4 +10,6 @@ module "s3_bucket" {
     enabled = true
   }
 
+
+  block_public_acls = true
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Allows Public ACL](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/ce8d4099cf9ba15092cc9766b26bb90af8271fae/iac-vulnerabilities?staticAnalysisId=AwAAAZY7HuuQ8Eu1JgAAABhBWlk3SEhES0FBQVM3d2FyenE5ZkFBQUEAAAAkMDE5NjNiMWUtZWU5OS00MDk2LWE2NWMtNjcxNzdkMTE4ZTI2AAAIsQ)