### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/negative2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/negative2.tf
@@ -10,4 +10,6 @@ module "s3_bucket" {
     enabled = true
   }
 
+  restrict_public_buckets = true
+  
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Without Restriction Of Public Bucket](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/947db21aea257cc5814e34a1b454f68b17f97ca5/iac-vulnerabilities?staticAnalysisId=AwAAAZZFlGMVrW4RaAAAABhBWlpGbEZ3WEFBRDVBMlhmSzlSYkFBQUEAAAAkMDE5NjQ1OTQtNmYxMy00ODBmLTliZTQtNjhhMzNkMGI4M2M2AAACPg)