### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive6.tf
@@ -6,4 +6,8 @@ module "s3_bucket" {
   bucket = "my-s3-bucket"
   acl    = "private"
 
+  versioning {
+  		 enabled = true
+  	}
+  
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Without Versioning](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4341/da78b3795f106d36c87e7c4a16505b1a44a6a355/iac-vulnerabilities?staticAnalysisId=AwAAAZZFrqJ3lhkECQAAABhBWlpGcnBvVkFBQzlhNGlqd0tZNUFBQUEAAAAkMDE5NjQ1YWUtYjk5Ny00MzBjLWEwZGYtYzg3YjVjMTVjNmJmAABJWA)