### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/docdb_logging_disabled/test/positive3.tf
+++ b/assets/queries/terraform/aws/docdb_logging_disabled/test/positive3.tf
@@ -7,5 +7,7 @@ resource "aws_docdb_cluster" "positive3" {
   preferred_backup_window = "07:00-09:00"
   skip_final_snapshot     = true
 
+  
+  storage_encrypted = true
   enabled_cloudwatch_logs_exports = ["profiler"]
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :red_circle: [DOCDB Cluster Not Encrypted](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4722/67c5e5a41c2284d1421b1b6df9eacceb3dfea5f9/iac-vulnerabilities?staticAnalysisId=AwAAAZZf-zGd80jcVQAAABhBWlpmLXlEVUFBQTZfVmN3eWlYc0FBQUEAAAAkMDE5NjVmZmItMzJjMC00YjBiLTgxNTAtZGE1MmM3M2IyMDdiAAAFsA)