### PR TITLE
[K9VULN-4722] Fix Terraform Line Detection Errors

### DIFF
--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -50,7 +50,7 @@ func (d defaultDetectLine) DetectLine(file *model.FileMetadata, searchKey string
 	}
 
 	for _, key := range splitSanitized {
-		substr1, substr2 := GenerateSubstrings(key, extractedString)
+		substr1, substr2 := GenerateSubstrings(key, extractedString, lines)
 
 		// BICEP-specific tweaks in order to make bicep files compatible with ARM queries
 		if file.Kind == "BICEP" {

--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -67,7 +67,7 @@ func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string,
 
 	// Since we are only looking at keys we can ignore the second value passed through '=' and '[]'
 	for _, key := range strings.Split(sanitizedSubstring, ".") {
-		substr1, _ := detector.GenerateSubstrings(key, extractedString)
+		substr1, _ := detector.GenerateSubstrings(key, extractedString, lines)
 		curLineRes = curLineRes.detectCurrentLine(lines, fmt.Sprintf("%s:", substr1), "", true, file.IDInfo, helmID)
 
 		if curLineRes.breakRes {

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -138,7 +138,6 @@ func parseAndFindTerraformBlock(src []byte, identifyingLine int) (model.Resource
 	if diagnostics != nil && diagnostics.HasErrors() {
 		return resourceStart, resourceEnd, lineContent, fmt.Errorf("failed to parse hcl file %s: %v", filePath, diagnostics.Errs())
 	}
-
 	for _, block := range hclSyntaxFile.Body.(*hclsyntax.Body).Blocks {
 		blockStart := block.TypeRange.Start
 		blockEnd := block.Body.SrcRange.End

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -45,7 +45,10 @@ func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string,
 	extractedString = detector.GetBracketValues(searchKey, extractedString, "")
 	sKey := searchKey
 	for idx, str := range extractedString {
-		sKey = strings.Replace(sKey, str[0], `{{`+strconv.Itoa(idx)+`}}`, -1)
+		// Only replace raw bracketed values (e.g., [abc]), not placeholders (e.g., [{{var}}])
+		if !strings.Contains(str[0], "{{") {
+			sKey = strings.Replace(sKey, str[0], `{{`+strconv.Itoa(idx)+`}}`, -1)
+		}
 	}
 
 	lines := *file.LinesOriginalData

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -52,7 +52,9 @@ func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string,
 	}
 
 	lines := *file.LinesOriginalData
-	splitSanitized := strings.Split(sKey, ".")
+	splitSanitized := strings.FieldsFunc(sKey, func(r rune) bool {
+		return r == '.' || r == '/'
+	})
 	for index, split := range splitSanitized {
 		if strings.Contains(split, "$ref") {
 			splitSanitized[index] = strings.Join(splitSanitized[index:], ".")

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -681,6 +681,20 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 			resultTags := append(tags, resourceTypeTag, resourceNameTag)
 
 			resourceLocation := vulnerability.ResourceLocation
+
+			if resourceLocation.ResourceStart.Line < 1 {
+				resourceLocation.ResourceStart.Line = 1
+			}
+			if resourceLocation.ResourceEnd.Line < 1 {
+				resourceLocation.ResourceEnd.Line = resourceLocation.ResourceStart.Line
+			}
+			if resourceLocation.ResourceStart.Col < 1 {
+				resourceLocation.ResourceStart.Col = 1
+			}
+			if resourceLocation.ResourceEnd.Col < 1 {
+				resourceLocation.ResourceEnd.Col = resourceLocation.ResourceStart.Col
+			}
+
 			startLocation := sarifResourceLocation{
 				Line: resourceLocation.ResourceStart.Line,
 				Col:  resourceLocation.ResourceStart.Col,
@@ -825,10 +839,8 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceL
 		before := strings.TrimSpace(patch["before"])
 		after := strings.TrimSpace(patch["after"])
 
-		// Regex to extract 'key = value' format
 		re := regexp.MustCompile(`(?m)["']?(?P<key>\w+)["']?\s*[:=]\s*(?P<value>\[.*?\]|".*?"|true|false|\d+)[,]?\s*`)
 		matches := re.FindStringSubmatch(vuln.LineWithVulnerability)
-
 		if len(matches) < 3 {
 			return sarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
 		}
@@ -836,100 +848,160 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceL
 		key := strings.TrimSpace(matches[1])
 		value := strings.TrimSpace(matches[2])
 
-		// Strip inline comment (from # or // onward)
 		if idx := strings.IndexAny(value, "#/"); idx != -1 {
 			value = strings.TrimSpace(value[:idx])
 		}
 
-		// Reconstruct the normalized key-value pair
 		fullLine := key + " = " + value
 
-		// Clean "before" for flexible matching
 		normalizedFullLine := normalize(fullLine)
 		normalizedValue := normalize(value)
-		normalizedBefore := normalize(before)
 
+		// Support multiple 'before' values separated by 'or'
+		normalizedAlternatives := []string{normalize(before)}
+		if strings.Contains(before, " or ") {
+			rawParts := strings.Split(before, " or ")
+			normalizedAlternatives = make([]string, 0, len(rawParts))
+			for _, part := range rawParts {
+				normalizedAlternatives = append(normalizedAlternatives, normalize(strings.TrimSpace(part)))
+			}
+		}
+
+		insertedText := ""
 		matched := false
 
-		if strings.Contains(normalizedBefore, "{") && strings.Contains(normalizedBefore, "=") {
-			reInner := regexp.MustCompile(`(?m)(\w+)\s*=\s*(".*?"|\S+)`)
-			for _, inner := range reInner.FindAllString(normalizedBefore, -1) {
+		for _, alt := range normalizedAlternatives {
+			altKey := ""
+			altValue := alt
+
+			if parts := strings.SplitN(alt, "=", 2); len(parts) == 2 {
+				altKey = normalize(strings.TrimSpace(parts[0]))
+				altValue = normalize(strings.TrimSpace(parts[1]))
+			} else {
+				altValue = normalize(alt)
+			}
+
+			if (alt == normalizedFullLine) ||
+				(altKey == normalize(key) && altValue == normalizedValue) ||
+				strings.Contains(normalizedValue, altValue) ||
+				strings.HasPrefix(normalizedValue, altValue) ||
+				strings.HasPrefix(altValue, normalizedValue) {
+				matched = true
+				break
+			}
+		}
+
+		// Block-style fallback (e.g., nested blocks like metadata_options)
+		if !matched && strings.Contains(normalize(before), "{") && strings.Contains(normalize(before), "=") {
+			reInner := regexp.MustCompile(`(?m)(\w+)\s*=\s*(".*?"|\[.*?\]|\S+)`)
+			for _, inner := range reInner.FindAllString(before, -1) {
 				n := normalize(inner)
-				if n == normalizedFullLine || n == normalizedValue {
-					matched = true
+				for _, alt := range normalizedAlternatives {
+					if n == normalizedFullLine || n == normalizedValue || strings.Contains(normalizedFullLine, n) || strings.Contains(n, alt) {
+						matched = true
+						break
+					}
+				}
+				if matched {
 					break
 				}
 			}
-		} else {
-			matched = normalizedBefore == normalizedFullLine || normalizedBefore == normalizedValue
+		}
 
-			// Enhanced: Support matching inside a list
-			if !matched && strings.HasPrefix(normalizedValue, "[") && strings.HasSuffix(normalizedValue, "]") {
-				listText := strings.Trim(normalizedValue, "[] ")
-				listItems := strings.Split(listText, ",")
+		// List-style fallback
+		if !matched && strings.HasPrefix(normalizedValue, "[") && strings.HasSuffix(normalizedValue, "]") {
+			listText := strings.Trim(normalizedValue, "[] ")
+			listItems := strings.Split(listText, ",")
 
-				newList := make([]string, 0, len(listItems))
-				replaced := false
+			newList := make([]string, 0, len(listItems))
+			replaced := false
 
-				for _, item := range listItems {
-					original := strings.TrimSpace(strings.Trim(item, `"`))
-					if normalize(original) == normalizedBefore {
+			// Pre-extract values from all alternatives (e.g., extract just "DISABLED" from "key = DISABLED")
+			normalizedAltValues := make([]string, 0, len(normalizedAlternatives))
+			for _, alt := range normalizedAlternatives {
+				parts := strings.SplitN(alt, "=", 2)
+				if len(parts) == 2 {
+					normalizedAltValues = append(normalizedAltValues, strings.TrimSpace(parts[1]))
+				} else {
+					normalizedAltValues = append(normalizedAltValues, strings.TrimSpace(alt))
+				}
+			}
+
+			for _, item := range listItems {
+				itemStripped := strings.TrimSpace(strings.Trim(item, `"`))
+				normOriginal := normalize(itemStripped)
+				replacedItem := false
+
+				for _, altVal := range normalizedAltValues {
+					normAltVal := normalize(altVal)
+
+					if normOriginal == normAltVal ||
+						strings.Contains(normOriginal, normAltVal) ||
+						strings.Contains(normAltVal, normOriginal) {
 						replaced = true
+						replacedItem = true
 						if strings.HasPrefix(item, `"`) && strings.HasSuffix(item, `"`) {
 							newList = append(newList, `"`+after+`"`)
 						} else {
 							newList = append(newList, after)
 						}
-					} else {
-						newList = append(newList, item)
+						break
 					}
 				}
 
-				if replaced {
-					joined := "[" + strings.Join(newList, ", ") + "]"
-					insertedText = strings.Replace(vuln.LineWithVulnerability, value, joined, 1)
-					matched = true
+				if !replacedItem {
+					newList = append(newList, item)
+				}
+			}
+
+			if replaced {
+				joined := "[" + strings.Join(newList, ", ") + "]"
+				insertedText = strings.Replace(vuln.LineWithVulnerability, value, joined, 1)
+				matched = true
+			} else {
+				// Check if the normalized list as a whole matches one of the alt values
+				for _, altVal := range normalizedAltValues {
+					if normalizedValue == normalize(altVal) {
+						matched = true
+						insertedText = vuln.LineWithVulnerability
+						break
+					}
 				}
 			}
 		}
 
 		if !matched {
-			return sarifFix{}, fmt.Errorf("line value '%s' does not match 'before' value '%s'", normalizedFullLine, normalizedBefore)
+			return sarifFix{}, fmt.Errorf("line value '%s' does not match any of expected values '%s'", normalizedFullLine, strings.Join(normalizedAlternatives, " | "))
 		}
 
-		// Determine if the after value is quoted if the original was
+		// Preserve quotes if necessary
 		wasQuoted := strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)
 		if wasQuoted && !(strings.HasPrefix(after, `"`) && strings.HasSuffix(after, `"`)) {
 			after = `"` + after + `"`
 		}
 
-		// Get regex indexes for replacement slicing
+		// Determine replacement range
 		idxs := re.FindStringSubmatchIndex(vuln.LineWithVulnerability)
 		if len(idxs) < 6 {
 			return sarifFix{}, fmt.Errorf("could not determine exact value location")
 		}
 
-		// Determine if 'after' is a full line or just a new value
 		isFullLine := strings.Contains(after, "=")
 
 		if insertedText == "" {
 			if isFullLine {
-				// If after is a full line like "key = newvalue", just replace the whole line
 				insertedText = after
 			} else {
-				// Just replace the value part of the line
-				prefix := vuln.LineWithVulnerability[:idxs[4]] // up to start of value
-				suffix := vuln.LineWithVulnerability[idxs[5]:] // after value
+				prefix := vuln.LineWithVulnerability[:idxs[4]]
+				suffix := vuln.LineWithVulnerability[idxs[5]:]
 				insertedText = prefix + after + suffix
 			}
 		}
 
-		// Position for SARIF fix
 		fixStart = sarifResourceLocation{
 			Line: vuln.Line,
 			Col:  startLocation.Col,
 		}
-
 		fixEnd = sarifResourceLocation{
 			Line: vuln.Line,
 			Col:  len(vuln.LineWithVulnerability) + 1,

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -867,7 +867,7 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation sarifResourceL
 			}
 		}
 
-		insertedText := ""
+		insertedText = ""
 		matched := false
 
 		for _, alt := range normalizedAlternatives {


### PR DESCRIPTION
We were getting errors like `Failed to detect Terraform line, query response: %s` for a variety of reasons.
This PR attempts to address each of the edge cases that caused this.

* SearchKey wasn't properly sanitized in some cases so logic to match on the resource was erroring out
* Search keys with {} and [{{label}}] were failing to properly be matched
* Handle aws_something[resource_name] search keys
* Handle raw bracketed values (e.g., [abc]) vs placeholders (e.g., [{{var}}]) correctly
* Support Terraform resource matching within lists
* Handle replacement remediation case where it is an entire line that needs to be replaced and not just an in-line value
* For GCP, handle resource paths with "/" and not just "."
* Support multiple 'before' values separated by 'or' in remediation
* Handle nested blocks like metadata_options for remediations instead of erroring
* Handle quoted, unquotes, encoded string in remediation replacements