### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/elasticsearch_using_default_security_group/test/negative2.tf
+++ b/assets/queries/terraform/aws/elasticsearch_using_default_security_group/test/negative2.tf
@@ -3,5 +3,9 @@ resource "aws_elasticsearch_domain" "good_example" {
 
   vpc_options {
 
+  
+  encrypt_at_rest {
+  	enabled = true
+  	}
   }
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :red_circle: [ElasticSearch Not Encrypted At Rest](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4722/67c5e5a41c2284d1421b1b6df9eacceb3dfea5f9/iac-vulnerabilities?staticAnalysisId=AwAAAZZf-zGd80jdeQAAABhBWlpmLXlEVUFBQlpHMjU2emw4RUFBQUEAAAAkMDE5NjVmZmItMzJjMC00YjBiLTgxNTAtZGE1MmM3M2IyMDdiAAAHag)