### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive2.tf
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive2.tf
@@ -12,6 +12,8 @@ resource "aws_ecs_task_definition" "service_2" {
       authorization_config {
         access_point_id = aws_efs_access_point.test.id
         iam             = "ENABLED"
+      
+      transit_encryption = "ENABLED"
       }
     }
   }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :red_circle: [ECS Task Definition Volume Not Encrypted](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4722/67c5e5a41c2284d1421b1b6df9eacceb3dfea5f9/iac-vulnerabilities?staticAnalysisId=AwAAAZZf-zGd80jdUQAAABhBWlpmLXlEVUFBQjlPSE9NbW1vZEFBQUEAAAAkMDE5NjVmZmItMzJjMC00YjBiLTgxNTAtZGE1MmM3M2IyMDdiAAAEsA)