### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/negative2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/negative2.tf
@@ -10,4 +10,6 @@ module "s3_bucket" {
     enabled = true
   }
 
-}
+
+ block_public_acls = true
+ }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Allows Public ACL](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4724/482cd9fc295f2b654e91f09cd589c8065b74b1c0/iac-vulnerabilities?staticAnalysisId=AwAAAZZos9urzUE_AQAAABhBWlpvczlXckFBREJFbWs4aklveEFBQUEAAAAkMDE5NjY4YmQtYWIyMS00NzMxLTgwYTEtYjI3NjJjYTAwOTRkAA_MVg)