### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/test/positive5.tf
@@ -7,7 +7,9 @@ module "s3_bucket" {
   acl    = "private"
 
   versioning = {
-    mfa_delete = true
+    
+          enabled = true
+mfa_delete = true
   }
 
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [S3 Bucket Without Versioning](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4724/dcb2773ed78861db54395e1aaa3cd29e7e7232df/iac-vulnerabilities?staticAnalysisId=AwAAAZZpLdiR2_QQkwAAABhBWlpwTGRONUFBQ1R5bWw3WG5nRUFBQUEAAAAkMDE5NjY5MmQtZTlmMS00MmYwLWI1MTEtMmUxODg2ZTRiZDc5AAAVfA)