### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/test/positive1.tf
@@ -10,7 +10,11 @@ resource "aws_launch_configuration" "positive1" {
 
   ebs_block_device {
     device_name = "/dev/xvda1"
-  }
+ 
+  metadata_options {
+   http_tokens = \"required\"
+ }
+   }
 }
 
 resource "aws_launch_configuration" "positive2" {


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :red_circle: [IMDSv1 Enabled](https://app-dev-local.datadoghq.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/bahar.shah%2FK9VULN-4724/6eb1c0d4c43ed5e244072f0abd5b29d249cf6267/iac-vulnerabilities?staticAnalysisId=AwAAAZaClWMt-OK_YQAAABhBWmFDbFZfNkFBQ1p5QThyVTBkNkFBQUEAAAAkMDE5NjgyOTUtNjc5Zi00NzA4LWI3YTktYjQ4Mjg3NjNkOTM0AAAEMQ)