### PR TITLE
Set module resource type and resource name instead of "n/a"

### DIFF
--- a/assets/queries/terraform/aws/alb_deletion_protection_disabled/query.rego
+++ b/assets/queries/terraform/aws/alb_deletion_protection_disabled/query.rego
@@ -56,8 +56,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'enable_deletion_protection' should be defined and set to true",
@@ -76,8 +76,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].enable_deletion_protection", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'enable_deletion_protection' should be set to true",

--- a/assets/queries/terraform/aws/alb_not_dropping_invalid_headers/query.rego
+++ b/assets/queries/terraform/aws/alb_not_dropping_invalid_headers/query.rego
@@ -61,8 +61,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].drop_invalid_header_fields", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].drop_invalid_header_fields should be set to true", [name]),
@@ -87,8 +87,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": module,
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("module[%s].drop_invalid_header_fields should be set to true", [name]),

--- a/assets/queries/terraform/aws/auto_scaling_group_with_no_associated_elb/query.rego
+++ b/assets/queries/terraform/aws/auto_scaling_group_with_no_associated_elb/query.rego
@@ -51,8 +51,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'load_balancers' should be set and not empty",
@@ -71,8 +71,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].load_balancers", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'load_balancers' should be set and not empty",

--- a/assets/queries/terraform/aws/automatic_minor_upgrades_disabled/query.rego
+++ b/assets/queries/terraform/aws/automatic_minor_upgrades_disabled/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].auto_minor_version_upgrade", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'auto_minor_version_upgrade' should be set to true",

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/query.rego
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/query.rego
@@ -29,8 +29,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'tags' should be defined and not null",

--- a/assets/queries/terraform/aws/ca_certificate_identifier_is_outdated/query.rego
+++ b/assets/queries/terraform/aws/ca_certificate_identifier_is_outdated/query.rego
@@ -28,8 +28,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].ca_cert_identifier", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ca_cert_identifier' should be one provided by Amazon RDS.",

--- a/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_is_publicly_accessible/query.rego
@@ -31,8 +31,8 @@ CxPolicy[result] {
 	module[keyToCheck] == publicAcl[_]
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s] to not be publicly accessible", [name]),

--- a/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_with_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_with_logging_disabled/query.rego
@@ -34,8 +34,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [moduleName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'logging' should be defined",

--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].storage_encrypted", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'storage_encrypted' should be set to true",
@@ -72,8 +72,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'storage_encrypted' should be set to true",

--- a/assets/queries/terraform/aws/default_vpc_exists/query.rego
+++ b/assets/queries/terraform/aws/default_vpc_exists/query.rego
@@ -26,8 +26,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("%s.%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_default_vpc' should not exist",

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/query.rego
@@ -31,8 +31,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'associate_public_ip_address' should be defined and not null",
@@ -69,8 +69,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].associate_public_ip_address", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'associate_public_ip_address' should be set to false",

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
@@ -30,8 +30,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'monitoring' should be defined and not null",
@@ -72,8 +72,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name,keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.'monitoring' should be set to true", [name]),

--- a/assets/queries/terraform/aws/ec2_instance_using_api_keys/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_using_api_keys/query.rego
@@ -96,8 +96,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("module[%s] should be using iam_instance_profile to assign a role with permissions", [name]),
@@ -115,8 +115,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("module[%s] should be using iam_instance_profile to assign a role with permissions", [name]),

--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/query.rego
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/query.rego
@@ -38,8 +38,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].ebs_optimized", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ebs_optimized' should be set to true",
@@ -85,8 +85,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'ebs_optimized' should be set to true",

--- a/assets/queries/terraform/aws/elb_access_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/elb_access_logging_disabled/query.rego
@@ -50,8 +50,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'access_logs' should be defined and not null",
@@ -70,8 +70,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s.enabled", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'access_logs.enabled' should be true",

--- a/assets/queries/terraform/aws/hardcoded_aws_access_key/query.rego
+++ b/assets/queries/terraform/aws/hardcoded_aws_access_key/query.rego
@@ -27,8 +27,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].user_data", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'user_data' shouldn't contain hardcoded access key",

--- a/assets/queries/terraform/aws/iam_database_auth_not_enabled/query.rego
+++ b/assets/queries/terraform/aws/iam_database_auth_not_enabled/query.rego
@@ -35,8 +35,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].iam_database_authentication_enabled", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'iam_database_authentication_enabled' should be set to true",
@@ -79,8 +79,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'iam_database_authentication_enabled' should be set to true",

--- a/assets/queries/terraform/aws/instance_with_no_vpc/query.rego
+++ b/assets/queries/terraform/aws/instance_with_no_vpc/query.rego
@@ -29,8 +29,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Attribute 'vpc_security_group_ids' should be defined and not null",

--- a/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/query.rego
@@ -52,8 +52,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s.encrypted", [name, block]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'encrypted' should be true",
@@ -76,8 +76,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, block]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'encrypted' should be set",

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/query.rego
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/query.rego
@@ -71,8 +71,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].%s[%d] 'RDP' (TCP:3389) should not be public", [name, keyToCheck, idx]),

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/query.rego
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/query.rego
@@ -71,8 +71,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_network_acl[%s].ingress[%d] 'SSH' (Port:22) should not be public", [name, idx]),

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/query.rego
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/query.rego
@@ -36,8 +36,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].iam_instance_profile", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Public and private instances should not share the same role",

--- a/assets/queries/terraform/aws/rds_db_instance_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/rds_db_instance_publicly_accessible/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].publicly_accessible", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'publicly_accessible' should be set to false or undefined",

--- a/assets/queries/terraform/aws/rds_with_backup_disabled/query.rego
+++ b/assets/queries/terraform/aws/rds_with_backup_disabled/query.rego
@@ -50,8 +50,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].backup_retention_period", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'backup_retention_period' should not equal '0'",
@@ -72,8 +72,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'backup_retention_period' should be defined, and bigger than '0'",

--- a/assets/queries/terraform/aws/rds_without_logging/query.rego
+++ b/assets/queries/terraform/aws/rds_without_logging/query.rego
@@ -44,8 +44,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'enabled_cloudwatch_logs_exports' should be defined",
@@ -61,8 +61,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].enabled_cloudwatch_logs_exports", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'enabled_cloudwatch_logs_exports' has one or more values",

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Principal' should not equal to, nor contain '*'",

--- a/assets/queries/terraform/aws/s3_bucket_acl_allows_read_or_write_to_all_users/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_allows_read_or_write_to_all_users/query.rego
@@ -29,8 +29,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'acl' should equal to 'private'",

--- a/assets/queries/terraform/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
@@ -29,8 +29,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'acl' should be private",

--- a/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' should not be a 'Delete' action",

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
@@ -27,8 +27,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s.Action", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].policy.Action should not be a 'Get' action", [name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' should not be a 'List' action when 'policy.Statement.Principal' contains '*'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_public_acl/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_public_acl/query.rego
@@ -50,8 +50,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'block_public_acls' should equal 'true'",
@@ -69,8 +69,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'block_public_acls' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' should not be a 'Put' action",

--- a/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
@@ -26,11 +26,11 @@ CxPolicy[result] {
     module := input.document[i].module[name]
     keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_s3_bucket", "logging")
     not common_lib.valid_key(module, keyToCheck)
-	
+
     result := {
         "documentId": input.document[i].id,
-        "resourceType": "n/a",
-		"resourceName": "n/a",
+        "resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
         "searchKey": sprintf("module[%s]", [name]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'logging' should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -36,8 +36,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy' should not accept HTTP Requests",

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
@@ -41,8 +41,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "S3 Bucket public ACL to not be overridden by public access block",

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement' should not allow all actions to all principal",

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
@@ -43,8 +43,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'block_public_policy' should equal 'true'",
@@ -60,8 +60,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'block_public_policy' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -49,8 +49,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",

--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
@@ -53,8 +53,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].versioning", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'%s' should be set to true", [checkedFields[c]]),
@@ -72,8 +72,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].versioning.%s", [name, checkedFields[c]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should be set to true", [checkedFields[c]]),

--- a/assets/queries/terraform/aws/s3_bucket_without_ignore_public_acl/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_ignore_public_acl/query.rego
@@ -50,8 +50,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].ignore_public_acls", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'ignore_public_acls' should equal 'true'",
@@ -70,8 +70,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].ignore_public_acls", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ignore_public_acls' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
@@ -31,8 +31,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",
@@ -51,8 +51,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].restrict_public_buckets", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
@@ -30,8 +30,8 @@ CxPolicy[result] {
 
     result := {
         "documentId": input.document[i].id,
-        "resourceType": "n/a",
-		"resourceName": "n/a",
+        "resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
         "searchKey": sprintf("module[%s]", [name]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'versioning' should be true",
@@ -71,8 +71,8 @@ CxPolicy[result] {
 
     result := {
         "documentId": input.document[i].id,
-        "resourceType": "n/a",
-		"resourceName": "n/a",
+        "resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
         "searchKey": sprintf("module[%s].versioning", [name]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'versioning.enabled' should be true",
@@ -114,8 +114,8 @@ CxPolicy[result] {
 
     result := {
         "documentId": input.document[i].id,
-        "resourceType": "n/a",
-		"resourceName": "n/a",
+        "resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
         "searchKey": sprintf("module[%s].versioning.enabled", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "'versioning.enabled' should be true",

--- a/assets/queries/terraform/aws/s3_static_website_host_enabled/query.rego
+++ b/assets/queries/terraform/aws/s3_static_website_host_enabled/query.rego
@@ -24,13 +24,13 @@ CxPolicy[result] {
 CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_s3_bucket", "website")
-	
+
 	count(module[keyToCheck]) > 0
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].website", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'website' to not have static websites inside",
@@ -40,9 +40,9 @@ CxPolicy[result] {
 }
 
 # version after TF AWS 4.0
-CxPolicy[result] {	
+CxPolicy[result] {
 	resource := input.document[i].resource.aws_s3_bucket[bucketName]
-	
+
 	tf_lib.has_target_resource(bucketName, "aws_s3_bucket_website_configuration")
 
 	result := {

--- a/assets/queries/terraform/aws/security_group_with_unrestricted_access_to_ssh/query.rego
+++ b/assets/queries/terraform/aws/security_group_with_unrestricted_access_to_ssh/query.rego
@@ -27,8 +27,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].ingress.cidr_blocks", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'SSH' (Port:22) should not be public",

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_wide_private_network/query.rego
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_wide_private_network/query.rego
@@ -45,8 +45,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, ingressKey]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s (%s:%d) should not be allowed", [portName, protocol, portNumber]),

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
@@ -47,8 +47,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].policy shouldn't have 'Effect: Allow' and 'NotAction' simultaneously", [name]),

--- a/assets/queries/terraform/aws/sqs_policy_allows_all_actions/query.rego
+++ b/assets/queries/terraform/aws/sqs_policy_allows_all_actions/query.rego
@@ -28,8 +28,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' should not equal '*'",

--- a/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
@@ -28,8 +28,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Principal' shouldn't get the queue publicly accessible",

--- a/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/query.rego
+++ b/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/query.rego
@@ -31,11 +31,11 @@ CxPolicy[result] {
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_vpc", "enable_dns_support")
 
 	module[keyToCheck] == false
-	
+
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].enable_dns_support", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'enable_dns_support' should be set to true or undefined",

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/query.rego
@@ -55,8 +55,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'kms_master_key_id' should be defined and not null",
@@ -89,8 +89,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'kms_master_key_id' should not be empty",

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/query.rego
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/query.rego
@@ -66,8 +66,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "One of 'ingress.cidr_blocks' not equal '0.0.0.0/0'",
@@ -139,8 +139,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' should not be equal to '::/0'",

--- a/assets/queries/terraform/aws/user_data_contains_encoded_private_key/query.rego
+++ b/assets/queries/terraform/aws/user_data_contains_encoded_private_key/query.rego
@@ -35,8 +35,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s].user_data_base64", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'user_data_base64' shouldn't contain RSA Private Key",

--- a/assets/queries/terraform/aws/vpc_flowlogs_disabled/query.rego
+++ b/assets/queries/terraform/aws/vpc_flowlogs_disabled/query.rego
@@ -47,8 +47,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("%s.%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.%s should be set to true", [name, keyToCheck]),
@@ -65,8 +65,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("%s", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.%s should be set to true", [name, keyToCheck]),

--- a/assets/queries/terraform/aws/vpc_subnet_assigns_public_ip/query.rego
+++ b/assets/queries/terraform/aws/vpc_subnet_assigns_public_ip/query.rego
@@ -33,8 +33,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("%s.%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.%s should be set to false", [name, keyToCheck]),
@@ -56,8 +56,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "module",
+		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("%s", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.map_public_ip_on_launch should be set to false", [name]),

--- a/assets/queries/terraform/general/generic_git_module_without_revision/query.rego
+++ b/assets/queries/terraform/general/generic_git_module_without_revision/query.rego
@@ -7,8 +7,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": module,
+		"resourceName": sprintf("%s", moduleName),
 		"searchKey": sprintf("module.{{%s}}.source", [moduleName]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Module 'source' field should have a reference",

--- a/assets/queries/terraform/general/output_without_description/query.rego
+++ b/assets/queries/terraform/general/output_without_description/query.rego
@@ -8,8 +8,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "output",
+		"resourceName": sprintf("%s", outputName),
 		"searchKey": sprintf("output.{{%s}}", [outputName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'description' should be defined and not null",
@@ -23,8 +23,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "output",
+		"resourceName": sprintf("%s", outputName),
 		"searchKey": sprintf("output.{{%s}}.description", [outputName]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'description' should not be empty",

--- a/assets/queries/terraform/general/variable_without_description/query.rego
+++ b/assets/queries/terraform/general/variable_without_description/query.rego
@@ -8,8 +8,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-	    "resourceType": "n/a",
-		"resourceName": "n/a",
+	    "resourceType": "variable",
+		"resourceName": sprintf("%s", variableName),
 		"searchKey": sprintf("variable.{{%s}}", [variableName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'description' should be defined and not null",
@@ -23,8 +23,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-	    "resourceType": "n/a",
-		"resourceName": "n/a",
+	    "resourceType": "variable",
+		"resourceName": sprintf("%s", variableName),
 		"searchKey": sprintf("variable.{{%s}}.description", [variableName]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'description' should not be empty",

--- a/assets/queries/terraform/general/variable_without_type/query.rego
+++ b/assets/queries/terraform/general/variable_without_type/query.rego
@@ -8,8 +8,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "variable",
+		"resourceName": sprintf("%s", variableName),
 		"searchKey": sprintf("variable.{{%s}}", [variableName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'type' should be defined and not null",
@@ -23,8 +23,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "variable",
+		"resourceName": sprintf("%s", variableName),
 		"searchKey": sprintf("variable.{{%s}}.type", [variableName]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'type' should not be empty",

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -641,12 +641,11 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 
 			resourceLocation := vulnerability.ResourceLocation
 
-			if resourceLocation.Start.Line < 1 {
-				resourceLocation.Start.Line = 1
+			if resourceLocation.Start.Line < 1 || resourceLocation.End.Line < 1 {
+				log.Warn().Msgf("Invalid resource location for file %s", issue.Files[idx].FileName)
+				continue
 			}
-			if resourceLocation.End.Line < 1 {
-				resourceLocation.End.Line = resourceLocation.Start.Line
-			}
+
 			if resourceLocation.Start.Col < 1 {
 				resourceLocation.Start.Col = 1
 			}

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -300,6 +300,9 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation model.SarifRes
 }
 
 func determineActualBaseIndent(fileLines []string, startLine int, blockStartLine int) string {
+	if startLine == 0 {
+		return ""
+	}
 	// Try to find the first non-empty, non-comment line above startLine within block
 	for i := startLine - 1; i >= blockStartLine-1; i-- {
 		line := strings.TrimSpace(fileLines[i])


### PR DESCRIPTION
We were previously setting n/a for resource type and resource name. Now we will instead set module and the name.