### PR TITLE
[K9VULN-4960] Refactor and add tests

### DIFF
--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -6,7 +6,6 @@
 package terraform
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -19,21 +18,15 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// DetectKindLine defines a kindDetectLine type
-type DetectKindLine struct {
-}
+type DetectKindLine struct{}
 
-const (
-	undetectedVulnerabilityLine = -1
-)
+const undetectedVulnerabilityLine = -1
 
 // DetectLine searches vulnerability line in terraform files
-func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string,
-	outputLines int, logwithfields *zerolog.Logger) model.VulnerabilityLines {
-	// Sanitize malformed Go formatting artifacts
+func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string, outputLines int, log *zerolog.Logger) model.VulnerabilityLines {
 	searchKey = sanitizeSearchKey(searchKey)
 
-	det := &detector.DefaultDetectLineResponse{
+	detection := &detector.DefaultDetectLineResponse{
 		CurrentLine:     0,
 		IsBreak:         false,
 		FoundAtLeastOne: false,
@@ -41,88 +34,53 @@ func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string,
 		ResolvedFiles:   make(map[string]model.ResolvedFileSplit),
 	}
 
-	var extractedString [][]string
-	extractedString = detector.GetBracketValues(searchKey, extractedString, "")
-	sKey := searchKey
-	for idx, str := range extractedString {
-		// Only replace raw bracketed values (e.g., [abc]), not placeholders (e.g., [{{var}}])
-		if !strings.Contains(str[0], "{{") {
-			sKey = strings.Replace(sKey, str[0], `{{`+strconv.Itoa(idx)+`}}`, -1)
+	extracted := detector.GetBracketValues(searchKey, [][]string{}, "")
+	normalizedKey := searchKey
+	for i, match := range extracted {
+		if !strings.Contains(match[0], "{{") {
+			normalizedKey = strings.Replace(normalizedKey, match[0], `{{`+strconv.Itoa(i)+`}}`, -1)
+		}
+	}
+
+	keyParts := strings.FieldsFunc(normalizedKey, func(r rune) bool {
+		return r == '.' || r == '/'
+	})
+	for i, part := range keyParts {
+		if strings.Contains(part, "$ref") {
+			keyParts = append(keyParts[:i+1], keyParts[i+1:]...)
+			break
 		}
 	}
 
 	lines := *file.LinesOriginalData
-	splitSanitized := strings.FieldsFunc(sKey, func(r rune) bool {
-		return r == '.' || r == '/'
-	})
-	for index, split := range splitSanitized {
-		if strings.Contains(split, "$ref") {
-			splitSanitized[index] = strings.Join(splitSanitized[index:], ".")
-			splitSanitized = splitSanitized[:index+1]
+
+	for _, part := range keyParts {
+		s1, s2 := detector.GenerateSubstrings(part, extracted, lines, detection.CurrentLine)
+		detection, _ = detection.DetectCurrentLine(s1, s2, 0, lines)
+		if detection.IsBreak {
 			break
 		}
 	}
 
-	for _, key := range splitSanitized {
-		substr1, substr2 := detector.GenerateSubstrings(key, extractedString, lines, det.CurrentLine)
-		det, _ = det.DetectCurrentLine(substr1, substr2, 0, lines)
-
-		if det.IsBreak {
-			break
-		}
-	}
-
-	if det.FoundAtLeastOne {
-		line := det.CurrentLine + 1
-
-		resourceStart, resourceEnd, remediationStart, remediationEnd, lineContent, resourceSource, blockStart, blockEnd, err := parseAndFindTerraformBlock([]byte(file.OriginalData), line)
+	if detection.FoundAtLeastOne {
+		line := detection.CurrentLine + 1
+		vulnLines, err := locateTerraformBlock([]byte(file.OriginalData), line, lines)
 		if err != nil {
-			fmt.Printf("Failed to parse and find Terraform block for line %d in file %s: %s\n", line, file.FilePath, err)
-			return model.VulnerabilityLines{
-				Line:         undetectedVulnerabilityLine,
-				VulnLines:    &[]model.CodeLine{},
-				ResolvedFile: file.FilePath,
-				VulnerablilityLocation: model.ResourceLocation{
-					Start: resourceStart,
-					End:   resourceEnd,
-				},
-				RemediationLocation: model.ResourceLocation{
-					Start: remediationStart,
-					End:   remediationEnd,
-				},
-				ResourceSource: resourceSource,
-				FileSource:     *file.LinesOriginalData,
-				BlockLocation: model.ResourceLocation{
-					Start: blockStart,
-					End:   blockEnd,
-				},
-			}
+			log.Error().Err(err).Msgf("Failed to parse block at line %d in file %s", line, file.FilePath)
+			return buildEmptyVulnerabilityLines(file)
 		}
-
-		return model.VulnerabilityLines{
-			Line:         line,
-			VulnLines:    detector.GetAdjacentVulnLines(det.CurrentLine, outputLines, lines),
-			ResolvedFile: file.FilePath,
-			VulnerablilityLocation: model.ResourceLocation{
-				Start: resourceStart,
-				End:   resourceEnd,
-			},
-			RemediationLocation: model.ResourceLocation{
-				Start: remediationStart,
-				End:   remediationEnd,
-			},
-			LineWithVulnerability: lineContent,
-			ResourceSource:        resourceSource,
-			FileSource:            *file.LinesOriginalData,
-			BlockLocation: model.ResourceLocation{
-				Start: blockStart,
-				End:   blockEnd,
-			},
-		}
+		vulnLines.Line = line
+		vulnLines.VulnLines = detector.GetAdjacentVulnLines(detection.CurrentLine, outputLines, lines)
+		vulnLines.ResolvedFile = file.FilePath
+		vulnLines.FileSource = lines
+		return vulnLines
 	}
 
-	logwithfields.Warn().Msgf("Failed to detect Terraform line, query response %s", sKey)
+	log.Warn().Msgf("Failed to detect Terraform line, query response %s", normalizedKey)
+	return buildEmptyVulnerabilityLines(file)
+}
 
+func buildEmptyVulnerabilityLines(file *model.FileMetadata) model.VulnerabilityLines {
 	return model.VulnerabilityLines{
 		Line:           undetectedVulnerabilityLine,
 		VulnLines:      &[]model.CodeLine{},
@@ -132,128 +90,149 @@ func (d DetectKindLine) DetectLine(file *model.FileMetadata, searchKey string,
 	}
 }
 
-type BlockInfo struct {
-	Block   *hclsyntax.Block
-	Depth   int
-	Parent  *hclsyntax.Block
-	IsMatch bool
-}
-
 func sanitizeSearchKey(key string) string {
-	// Replace any instance of [%!s(int=N)] with [N]
 	re := regexp.MustCompile(`\[%!s\(int=(\d+)\)\]`)
 	return re.ReplaceAllString(key, "[$1]")
 }
 
-func parseAndFindTerraformBlock(src []byte, identifyingLine int) (model.ResourceLine, model.ResourceLine, model.ResourceLine, model.ResourceLine, string, string, model.ResourceLine, model.ResourceLine, error) {
+func locateTerraformBlock(src []byte, identifyingLine int, strLines []string) (model.VulnerabilityLines, error) {
 	filePath := "temp.tf"
-	lines := bytes.Split(src, []byte("\n"))
 
-	if identifyingLine <= 0 || identifyingLine > len(lines) {
-		return model.ResourceLine{}, model.ResourceLine{}, model.ResourceLine{}, model.ResourceLine{}, "", "", model.ResourceLine{}, model.ResourceLine{}, fmt.Errorf("line %d is out of range", identifyingLine)
+	if identifyingLine <= 0 || identifyingLine > len(strLines) {
+		return model.VulnerabilityLines{}, fmt.Errorf("line %d is out of range", identifyingLine)
 	}
 
-	lineContent := string(lines[identifyingLine-1])
-	var vulnerabilitySource string
-
-	vulnerabilityStart := model.ResourceLine{Line: -1, Col: -1}
-	vulnerabilityEnd := model.ResourceLine{Line: -1, Col: -1}
-	remediationStart := model.ResourceLine{Line: -1, Col: -1}
-	remediationEnd := model.ResourceLine{Line: -1, Col: -1}
-	blockLocationStart := model.ResourceLine{Line: -1, Col: -1}
-	blockLocationEnd := model.ResourceLine{Line: -1, Col: -1}
-
-	hclSyntaxFile, diagnostics := hclsyntax.ParseConfig(src, filePath, hcl.InitialPos)
-	if diagnostics != nil && diagnostics.HasErrors() {
-		return vulnerabilityStart, vulnerabilityEnd, remediationStart, remediationEnd, lineContent, "", blockLocationStart, blockLocationEnd, fmt.Errorf("failed to parse HCL file %s: %v", filePath, diagnostics.Errs())
+	hclFile, diagnostics := hclsyntax.ParseConfig(src, filePath, hcl.InitialPos)
+	if diagnostics.HasErrors() {
+		return model.VulnerabilityLines{}, fmt.Errorf("failed to parse HCL: %v", diagnostics.Errs())
 	}
 
-	blocks := hclSyntaxFile.Body.(*hclsyntax.Body).Blocks
+	body, ok := hclFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return model.VulnerabilityLines{}, fmt.Errorf("unexpected HCL body type")
+	}
 
-	for _, block := range blocks {
-		blockStart := block.TypeRange.Start
-		blockEnd := block.Body.SrcRange.End
+	for _, block := range body.Blocks {
+		start := block.TypeRange.Start
+		end := block.Body.SrcRange.End
+		if identifyingLine >= start.Line && identifyingLine <= end.Line {
+			blockSrc := extractBlockSource(strLines, start.Line, end.Line)
 
-		blockLines := lines[blockStart.Line-1 : blockEnd.Line]
-		var sb strings.Builder
-		for _, l := range blockLines {
-			sb.Write(l)
-			sb.WriteByte('\n')
-		}
-		vulnerabilitySource = sb.String()
-
-		if identifyingLine >= blockStart.Line && identifyingLine <= blockEnd.Line {
-			var insertionLine int
-			var insertionCol int
-			var caseType string
-
-			structureName, nestedStart, nestedEnd, _ := findContainingStructure(block, identifyingLine)
-
-			if structureName != "" {
-				if identifyingLine == nestedEnd.Line {
-					insertionLine = nestedEnd.Line - 1
-					caseType = "nested-end"
-				} else if identifyingLine == nestedStart.Line {
-					insertionLine = nestedStart.Line + 1
-					caseType = "nested-start"
-				} else {
-					insertionLine = identifyingLine
-					caseType = "nested-body"
-				}
-			} else {
-				if identifyingLine == blockStart.Line {
-					insertionLine = blockEnd.Line - 1
-					for i := insertionLine; i >= blockStart.Line; i-- {
-						_, nestedStart, nestedEnd, isAttr := findContainingStructure(block, i)
-						if isAttr && nestedEnd.Line >= insertionLine {
-							insertionLine = nestedStart.Line - 1
-							continue
-						}
-						break
-					}
-					caseType = "block-start"
-				} else {
-					insertionLine = identifyingLine
-					caseType = "block-body"
-				}
-			}
-
-			insertionCol = determineInsertionIndent(
-				toStringLines(lines),
-				insertionLine,
-				caseType,
-				nestedStart.Line,
-				nestedEnd.Line,
-				blockStart.Line,
-				blockEnd.Line,
-			) + 1
-
-			// if this is block start and the insertion line contains } we want to insert at the end and not at the start
-			trimmedLine := strings.TrimSpace(string(lines[insertionLine-1]))
-			if caseType == "block-start" && (trimmedLine == "}" || isHeredocTerminator(trimmedLine, lines, insertionLine-1)) {
-				insertionCol = len(lines[insertionLine-1]) + 1
-			}
-
-			remediationStart = model.ResourceLine{Line: insertionLine, Col: insertionCol}
-			remediationEnd = model.ResourceLine{Line: insertionLine, Col: insertionCol}
-			vulnerabilityStart = model.ResourceLine{Line: blockStart.Line, Col: blockStart.Column}
-			vulnerabilityEnd = model.ResourceLine{Line: blockEnd.Line, Col: blockEnd.Column}
-			blockLocationStart = model.ResourceLine{Line: blockStart.Line, Col: blockStart.Column}
-			blockLocationEnd = model.ResourceLine{Line: blockEnd.Line, Col: blockEnd.Column}
-
-			return vulnerabilityStart, vulnerabilityEnd, remediationStart, remediationEnd, lineContent, vulnerabilitySource, blockLocationStart, blockLocationEnd, nil
+			insertionLine, insertionCol := calculateInsertionPoint(block, identifyingLine, strLines)
+			return model.VulnerabilityLines{
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: toResourceLine(start),
+					End:   toResourceLine(end),
+				},
+				RemediationLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Line: insertionLine, Col: insertionCol},
+					End:   model.ResourceLine{Line: insertionLine, Col: insertionCol},
+				},
+				BlockLocation: model.ResourceLocation{
+					Start: toResourceLine(start),
+					End:   toResourceLine(end),
+				},
+				LineWithVulnerability: string(strLines[identifyingLine-1]),
+				ResourceSource:        blockSrc,
+			}, nil
 		}
 	}
 
-	return model.ResourceLine{}, model.ResourceLine{}, model.ResourceLine{}, model.ResourceLine{}, "", "", model.ResourceLine{}, model.ResourceLine{}, fmt.Errorf("failed to locate block for line %d", identifyingLine)
+	return model.VulnerabilityLines{}, fmt.Errorf("failed to locate block for line %d", identifyingLine)
 }
 
-func toStringLines(byteLines [][]byte) []string {
-	result := make([]string, len(byteLines))
-	for i, b := range byteLines {
-		result[i] = string(b)
+func toResourceLine(pos hcl.Pos) model.ResourceLine {
+	return model.ResourceLine{Line: pos.Line, Col: pos.Column}
+}
+
+func extractBlockSource(lines []string, start, end int) string {
+	return string(strings.Join(lines[start-1:end], "\n")) + "\n"
+}
+
+func calculateInsertionPoint(block *hclsyntax.Block, line int, lines []string) (int, int) {
+	name, nestedStart, nestedEnd, _ := findContainingStructure(block, line)
+
+	var insertionLine int
+	var caseType string
+
+	if name != "" {
+		switch {
+		case line == nestedEnd.Line:
+			insertionLine = nestedEnd.Line - 1
+			caseType = "nested-end"
+		case line == nestedStart.Line:
+			insertionLine = nestedStart.Line + 1
+			caseType = "nested-start"
+		default:
+			insertionLine = line
+			caseType = "nested-body"
+		}
+	} else {
+		if line == block.TypeRange.Start.Line {
+			insertionLine = block.Body.SrcRange.End.Line - 1
+			for i := insertionLine; i >= block.TypeRange.Start.Line; i-- {
+				_, s, e, attr := findContainingStructure(block, i)
+				if attr && e.Line >= insertionLine {
+					insertionLine = s.Line - 1
+				} else {
+					break
+				}
+			}
+			caseType = "block-start"
+		} else {
+			insertionLine = line
+			caseType = "block-body"
+		}
 	}
-	return result
+
+	col := determineInsertionIndent(lines, insertionLine, caseType, nestedStart.Line, nestedEnd.Line, block.TypeRange.Start.Line, block.Body.SrcRange.End.Line) + 1
+	trimmed := strings.TrimSpace(lines[insertionLine-1])
+	if caseType == "block-start" && (trimmed == "}" || isHeredocTerminator(trimmed, lines, insertionLine-1)) {
+		col = len(lines[insertionLine-1]) + 1
+	}
+	return insertionLine, col
+}
+
+func findContainingStructure(block *hclsyntax.Block, line int) (string, hcl.Pos, hcl.Pos, bool) {
+	for _, nested := range block.Body.Blocks {
+		if line >= nested.TypeRange.Start.Line && line <= nested.Body.SrcRange.End.Line {
+			if name, s, e, isAttr := findContainingStructure(nested, line); name != "" {
+				return name, s, e, isAttr
+			}
+			return nested.Type, nested.TypeRange.Start, nested.Body.SrcRange.End, false
+		}
+	}
+	for name, attr := range block.Body.Attributes {
+		if _, ok := attr.Expr.(*hclsyntax.ObjectConsExpr); ok {
+			if line >= attr.SrcRange.Start.Line && line <= attr.SrcRange.End.Line {
+				return name, attr.SrcRange.Start, attr.SrcRange.End, true
+			}
+		}
+	}
+	return "", hcl.Pos{}, hcl.Pos{}, false
+}
+
+func determineInsertionIndent(lines []string, insertionLine int, caseType string, nestedStart, nestedEnd, blockStart, blockEnd int) int {
+	switch caseType {
+	case "nested-end":
+		for i := nestedEnd - 2; i >= nestedStart-1; i-- {
+			if trimmed := strings.TrimSpace(lines[i]); trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				return countLeadingSpacesOrTabs([]byte(lines[i]))
+			}
+		}
+	case "nested-start":
+		return countLeadingSpacesOrTabs([]byte(lines[nestedStart-1])) + 2
+	case "nested-body", "block-body":
+		return countLeadingSpacesOrTabs([]byte(lines[insertionLine-1]))
+	case "block-start":
+		if strings.TrimSpace(lines[insertionLine-1]) != "}" {
+			if idx := firstNonWhitespaceIndex(lines[insertionLine-1]); idx != -1 {
+				return idx
+			}
+		}
+		return 1
+	}
+	return 0
 }
 
 func countLeadingSpacesOrTabs(line []byte) int {
@@ -268,68 +247,6 @@ func countLeadingSpacesOrTabs(line []byte) int {
 	return count
 }
 
-// findContainingStructure returns the name, start, and end of a nested block or attribute containing the line.
-// If the line is not part of a nested block or object-style attribute, it returns empty string and zero positions.
-func findContainingStructure(block *hclsyntax.Block, line int) (string, hcl.Pos, hcl.Pos, bool) {
-	for _, nested := range block.Body.Blocks {
-		start := nested.TypeRange.Start
-		end := nested.Body.SrcRange.End
-		if line >= start.Line && line <= end.Line {
-			if deeperType, deeperStart, deeperEnd, isAttr := findContainingStructure(nested, line); deeperType != "" {
-				return deeperType, deeperStart, deeperEnd, isAttr
-			}
-			return nested.Type, start, end, false
-		}
-	}
-
-	for name, attr := range block.Body.Attributes {
-		if _, ok := attr.Expr.(*hclsyntax.ObjectConsExpr); ok {
-			start := attr.SrcRange.Start
-			end := attr.SrcRange.End
-			if line >= start.Line && line <= end.Line {
-				return name, start, end, true
-			}
-		}
-	}
-
-	return "", hcl.Pos{}, hcl.Pos{}, false
-}
-
-// determineInsertionIndent determines correct indentation based on insertion case.
-func determineInsertionIndent(lines []string, insertionLine int, caseType string, nestedStart int, nestedEnd int, blockStart int, blockEnd int) int {
-	switch caseType {
-	case "nested-end":
-		// Look upwards inside nested block
-		for i := nestedEnd - 2; i >= nestedStart-1; i-- {
-			trimmed := strings.TrimSpace(lines[i])
-			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
-				return countLeadingSpacesOrTabs([]byte(lines[i]))
-			}
-		}
-	case "nested-start":
-		// 2 spaces deeper than nested block header
-		return countLeadingSpacesOrTabs([]byte(lines[nestedStart-1])) + 2
-	case "nested-body":
-		// Match current line
-		return countLeadingSpacesOrTabs([]byte(lines[insertionLine-1]))
-	case "block-start":
-		// if line being inserted at is not } then we want to insert at the start of the content
-		if strings.TrimSpace(lines[insertionLine-1]) != "}" {
-			nonWhitespaceIndex := firstNonWhitespaceIndex(lines[insertionLine-1])
-			if nonWhitespaceIndex != -1 {
-				return nonWhitespaceIndex
-			}
-		}
-
-		// 2 spaces deeper than block header
-		return 1
-	case "block-body":
-		// Match current line
-		return countLeadingSpacesOrTabs([]byte(lines[insertionLine-1]))
-	}
-	return 0
-}
-
 func firstNonWhitespaceIndex(line string) int {
 	for i, r := range line {
 		if r != ' ' && r != '\t' {
@@ -339,10 +256,9 @@ func firstNonWhitespaceIndex(line string) int {
 	return -1
 }
 
-func isHeredocTerminator(line string, lines [][]byte, idx int) bool {
-	// Scan backward for heredoc start
+func isHeredocTerminator(line string, lines []string, idx int) bool {
 	for i := idx - 1; i >= 0; i-- {
-		text := strings.TrimSpace(string(lines[i]))
+		text := strings.TrimSpace(lines[i])
 		if strings.Contains(text, "<<") {
 			parts := strings.Split(text, "<<")
 			if len(parts) == 2 {

--- a/pkg/detector/terraform/terraform_detect_test.go
+++ b/pkg/detector/terraform/terraform_detect_test.go
@@ -116,12 +116,8 @@ func TestDetectTerraformLine(t *testing.T) { //nolint
 		},
 		{
 			expected: model.VulnerabilityLines{
-				Line: 14,
+				Line: 15,
 				VulnLines: &[]model.CodeLine{
-					{
-						Position: 13,
-						Line:     "",
-					},
 					{
 						Position: 14,
 						Line:     "resource \"aws_s3_bucket\" \"bucket2\" {",
@@ -130,8 +126,12 @@ func TestDetectTerraformLine(t *testing.T) { //nolint
 						Position: 15,
 						Line:     "  bucket = \"innovationweek2-2023-bucket-${random_id.bucket_id.hex}\"",
 					},
+					{
+						Position: 16,
+						Line:     "",
+					},
 				},
-				LineWithVulnerability: "resource \"aws_s3_bucket\" \"bucket2\" {",
+				LineWithVulnerability: "  bucket = \"innovationweek2-2023-bucket-${random_id.bucket_id.hex}\"",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
 						Line: 14,
@@ -156,12 +156,12 @@ func TestDetectTerraformLine(t *testing.T) { //nolint
 				FileSource:     strings.Split(OriginalData1, "\n"),
 				RemediationLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 16,
-						Col:  2,
+						Line: 15,
+						Col:  3,
 					},
 					End: model.ResourceLine{
-						Line: 16,
-						Col:  2,
+						Line: 15,
+						Col:  3,
 					},
 				},
 			},
@@ -420,6 +420,108 @@ func TestDetectTerraformLineRemediations(t *testing.T) {
 				Kind:              model.KindTerraform,
 				OriginalData:      OriginalDataMissingVersioning,
 				LinesOriginalData: utils.SplitLines(OriginalDataMissingVersioning),
+			},
+		},
+		{
+			expected: model.VulnerabilityLines{
+				Line: 4,
+				VulnLines: &[]model.CodeLine{
+					{Position: 3, Line: "    configuration {"},
+					{Position: 4, Line: "      status = \"Enabled\""},
+					{Position: 5, Line: "    }"},
+				},
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 2, Line: 7},
+				},
+				RemediationLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 7, Line: 4},
+					End:   model.ResourceLine{Col: 7, Line: 4},
+				},
+				LineWithVulnerability: "      status = \"Enabled\"",
+				ResolvedFile:          "",
+				ResourceSource:        "resource \"aws_s3_bucket\" \"example\" {\n  versioning {\n    configuration {\n      status = \"Enabled\"\n    }\n  }\n}\n",
+				FileSource:            strings.Split("resource \"aws_s3_bucket\" \"example\" {\n  versioning {\n    configuration {\n      status = \"Enabled\"\n    }\n  }\n}\n", "\n"),
+				BlockLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 2, Line: 7},
+				},
+			},
+			searchKey: "aws_s3_bucket[example].versioning.configuration.status",
+			file: &model.FileMetadata{
+				ScanID:            "deep",
+				ID:                "deep-nested",
+				Kind:              model.KindTerraform,
+				OriginalData:      "resource \"aws_s3_bucket\" \"example\" {\n  versioning {\n    configuration {\n      status = \"Enabled\"\n    }\n  }\n}\n",
+				LinesOriginalData: utils.SplitLines("resource \"aws_s3_bucket\" \"example\" {\n  versioning {\n    configuration {\n      status = \"Enabled\"\n    }\n  }\n}\n"),
+			},
+		},
+		{
+			expected: model.VulnerabilityLines{
+				Line: 3,
+				VulnLines: &[]model.CodeLine{
+					{Position: 2, Line: "  statement = [{"},
+					{Position: 3, Line: "    actions = [\"s3:GetObject\"]"},
+					{Position: 4, Line: "  }]"},
+				},
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 2, Line: 5},
+				},
+				RemediationLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 5, Line: 3},
+					End:   model.ResourceLine{Col: 5, Line: 3},
+				},
+				LineWithVulnerability: "    actions = [\"s3:GetObject\"]",
+				ResolvedFile:          "",
+				ResourceSource:        "resource \"aws_iam_policy_document\" \"example\" {\n  statement = [{\n    actions = [\"s3:GetObject\"]\n  }]\n}\n",
+				FileSource:            strings.Split("resource \"aws_iam_policy_document\" \"example\" {\n  statement = [{\n    actions = [\"s3:GetObject\"]\n  }]\n}\n", "\n"),
+				BlockLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 2, Line: 5},
+				},
+			},
+			searchKey: "aws_iam_policy_document[example].statement[0].actions[0]",
+			file: &model.FileMetadata{
+				ScanID:            "indexing",
+				ID:                "policy.actions",
+				Kind:              model.KindTerraform,
+				OriginalData:      "resource \"aws_iam_policy_document\" \"example\" {\n  statement = [{\n    actions = [\"s3:GetObject\"]\n  }]\n}\n",
+				LinesOriginalData: utils.SplitLines("resource \"aws_iam_policy_document\" \"example\" {\n  statement = [{\n    actions = [\"s3:GetObject\"]\n  }]\n}\n"),
+			},
+		},
+		{
+			expected: model.VulnerabilityLines{
+				Line: 1,
+				VulnLines: &[]model.CodeLine{
+					{Position: 1, Line: "resource \"aws_instance\" \"example\" {"},
+					{Position: 2, Line: "  tags = {"},
+					{Position: 3, Line: "    Name = \"web-server\""},
+				},
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 2, Line: 5},
+				},
+				RemediationLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 1, Line: 1},
+				},
+				LineWithVulnerability: "resource \"aws_instance\" \"example\" {",
+				ResolvedFile:          "",
+				ResourceSource:        "resource \"aws_instance\" \"example\" {\n  tags = {\n    Name = \"web-server\"\n  }\n}\n",
+				FileSource:            strings.Split("resource \"aws_instance\" \"example\" {\n  tags = {\n    Name = \"web-server\"\n  }\n}\n", "\n"),
+				BlockLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Col: 1, Line: 1},
+					End:   model.ResourceLine{Col: 2, Line: 5},
+				},
+			},
+			searchKey: "aws_instance[example].tags[\"Name\"]",
+			file: &model.FileMetadata{
+				ScanID:            "mapkey",
+				ID:                "tags.name",
+				Kind:              model.KindTerraform,
+				OriginalData:      "resource \"aws_instance\" \"example\" {\n  tags = {\n    Name = \"web-server\"\n  }\n}\n",
+				LinesOriginalData: utils.SplitLines("resource \"aws_instance\" \"example\" {\n  tags = {\n    Name = \"web-server\"\n  }\n}\n"),
 			},
 		},
 	}

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -10,283 +10,193 @@ import (
 )
 
 func TransformToSarifFix(vuln model.VulnerableFile, startLocation model.SarifResourceLocation, endLocation model.SarifResourceLocation) (model.SarifFix, error) {
-	var insertedText string
-	fixStart := startLocation
-	fixEnd := endLocation
-
 	switch vuln.RemediationType {
 	case "replacement":
-		var patch map[string]string
-		err := json.Unmarshal([]byte(vuln.Remediation), &patch)
-		if err != nil {
-			return model.SarifFix{}, fmt.Errorf("invalid remediation format for replacement: %v", err)
+		return buildReplacementFix(vuln, startLocation, endLocation)
+	case "addition":
+		return buildAdditionFix(vuln, startLocation)
+	case "removal":
+		return buildRemovalFix(vuln, startLocation, endLocation)
+	default:
+		return model.SarifFix{}, fmt.Errorf("unsupported remediation type: %s", vuln.RemediationType)
+	}
+}
+
+func buildReplacementFix(vuln model.VulnerableFile, startLocation, endLocation model.SarifResourceLocation) (model.SarifFix, error) {
+	var patch map[string]string
+	if err := json.Unmarshal([]byte(vuln.Remediation), &patch); err != nil {
+		return model.SarifFix{}, fmt.Errorf("invalid remediation format for replacement: %v", err)
+	}
+
+	before := strings.TrimSpace(patch["before"])
+	after := strings.TrimSpace(patch["after"])
+
+	// Regex for key and value (list/quoted/unquoted)
+	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*[:=]\s*(\[.*?\]|".*?"|[^#]+)`)
+	matches := keyValRegex.FindStringSubmatch(vuln.LineWithVulnerability)
+	if len(matches) < 3 {
+		return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
+	}
+
+	key := strings.TrimSpace(matches[1])
+	rawValue := strings.TrimSpace(matches[2])
+	normalizedFullLine := normalize(fmt.Sprintf("%s = %s", key, rawValue))
+	normalizedRawValue := normalize(rawValue)
+
+	leadingWhitespace := determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
+
+	// Extract alternative values (just the value parts)
+	altValues := parseAlternatives(before)
+
+	matched := false
+	insertedText := ""
+
+	// First try direct match (for flat key=value lines)
+	for _, alt := range altValues {
+		altKV := normalize(fmt.Sprintf("%s = %s", key, alt))
+		if altKV == normalizedFullLine || strings.Contains(normalizedRawValue, alt) {
+			matched = true
+			break
 		}
+	}
 
-		before := strings.TrimSpace(patch["before"])
-		after := strings.TrimSpace(patch["after"])
+	// List fallback matching
+	if !matched && strings.HasPrefix(rawValue, "[") && strings.HasSuffix(rawValue, "]") {
+		// Parse the list from the raw value (preserves quotes)
+		listRaw := strings.Trim(rawValue, "[] ")
+		items := strings.Split(listRaw, ",")
 
-		re := regexp.MustCompile(`(?m)["']?(?P<key>\w+)["']?\s*[:=]\s*(?P<value>\[.*?\]|".*?"|true|false|\d+)[,]?\s*`)
-		matches := re.FindStringSubmatch(vuln.LineWithVulnerability)
-		if len(matches) < 3 {
-			return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
-		}
+		replaced := false
+		newList := make([]string, 0, len(items))
 
-		key := strings.TrimSpace(matches[1])
-		value := strings.TrimSpace(matches[2])
+		for _, item := range items {
+			trimmed := strings.TrimSpace(strings.Trim(item, `"`))
+			norm := normalize(trimmed)
+			replacedItem := false
 
-		leadingWhitespace := determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
-
-		if idx := strings.IndexAny(value, "#/"); idx != -1 {
-			value = strings.TrimSpace(value[:idx])
-		}
-
-		fullLine := key + " = " + value
-
-		normalizedFullLine := normalize(fullLine)
-		normalizedValue := normalize(value)
-
-		// Support multiple 'before' values separated by 'or'
-		normalizedAlternatives := []string{normalize(before)}
-		if strings.Contains(before, " or ") {
-			rawParts := strings.Split(before, " or ")
-			normalizedAlternatives = make([]string, 0, len(rawParts))
-			for _, part := range rawParts {
-				normalizedAlternatives = append(normalizedAlternatives, normalize(strings.TrimSpace(part)))
-			}
-		}
-
-		insertedText = ""
-		matched := false
-
-		for _, alt := range normalizedAlternatives {
-			altKey := ""
-			altValue := alt
-
-			if parts := strings.SplitN(alt, "=", 2); len(parts) == 2 {
-				altKey = normalize(strings.TrimSpace(parts[0]))
-				altValue = normalize(strings.TrimSpace(parts[1]))
-			} else {
-				altValue = normalize(alt)
-			}
-
-			if (alt == normalizedFullLine) ||
-				(altKey == normalize(key) && altValue == normalizedValue) ||
-				strings.Contains(normalizedValue, altValue) ||
-				strings.HasPrefix(normalizedValue, altValue) ||
-				strings.HasPrefix(altValue, normalizedValue) {
-				matched = true
-				break
-			}
-		}
-
-		// Block-style fallback (e.g., nested blocks like metadata_options)
-		if !matched && strings.Contains(normalize(before), "{") && strings.Contains(normalize(before), "=") {
-			reInner := regexp.MustCompile(`(?m)(\w+)\s*=\s*(".*?"|\[.*?\]|\S+)`)
-			for _, inner := range reInner.FindAllString(before, -1) {
-				n := normalize(inner)
-				for _, alt := range normalizedAlternatives {
-					if n == normalizedFullLine || n == normalizedValue || strings.Contains(normalizedFullLine, n) || strings.Contains(n, alt) {
-						matched = true
-						break
+			for _, alt := range altValues {
+				if norm == alt {
+					replaced = true
+					replacedItem = true
+					if strings.HasPrefix(item, `"`) && strings.HasSuffix(item, `"`) {
+						newList = append(newList, `"`+after+`"`)
+					} else {
+						newList = append(newList, after)
 					}
-				}
-				if matched {
 					break
 				}
 			}
-		}
 
-		// List-style fallback
-		if !matched && strings.HasPrefix(normalizedValue, "[") && strings.HasSuffix(normalizedValue, "]") {
-			listText := strings.Trim(normalizedValue, "[] ")
-			listItems := strings.Split(listText, ",")
-
-			newList := make([]string, 0, len(listItems))
-			replaced := false
-
-			// Pre-extract values from all alternatives (e.g., extract just "DISABLED" from "key = DISABLED")
-			normalizedAltValues := make([]string, 0, len(normalizedAlternatives))
-			for _, alt := range normalizedAlternatives {
-				parts := strings.SplitN(alt, "=", 2)
-				if len(parts) == 2 {
-					normalizedAltValues = append(normalizedAltValues, strings.TrimSpace(parts[1]))
-				} else {
-					normalizedAltValues = append(normalizedAltValues, strings.TrimSpace(alt))
-				}
-			}
-
-			for _, item := range listItems {
-				itemStripped := strings.TrimSpace(strings.Trim(item, `"`))
-				normOriginal := normalize(itemStripped)
-				replacedItem := false
-
-				for _, altVal := range normalizedAltValues {
-					normAltVal := normalize(altVal)
-
-					if normOriginal == normAltVal ||
-						strings.Contains(normOriginal, normAltVal) ||
-						strings.Contains(normAltVal, normOriginal) {
-						replaced = true
-						replacedItem = true
-						if strings.HasPrefix(item, `"`) && strings.HasSuffix(item, `"`) {
-							newList = append(newList, `"`+after+`"`)
-						} else {
-							newList = append(newList, after)
-						}
-						break
-					}
-				}
-
-				if !replacedItem {
-					newList = append(newList, item)
-				}
-			}
-
-			if replaced {
-				joined := "[" + strings.Join(newList, ", ") + "]"
-				insertedText = strings.Replace(vuln.LineWithVulnerability, value, joined, 1)
-				matched = true
-			} else {
-				// Check if the normalized list as a whole matches one of the alt values
-				for _, altVal := range normalizedAltValues {
-					if normalizedValue == normalize(altVal) {
-						matched = true
-						insertedText = vuln.LineWithVulnerability
-						break
-					}
-				}
+			if !replacedItem {
+				newList = append(newList, item)
 			}
 		}
 
-		if !matched {
-			return model.SarifFix{}, fmt.Errorf("line value '%s' does not match any of expected values '%s'", normalizedFullLine, strings.Join(normalizedAlternatives, " | "))
+		if replaced {
+			rebuilt := "[" + strings.Join(newList, ", ") + "]"
+			insertedText = fmt.Sprintf("%s = %s", key, rebuilt)
+			matched = true
 		}
+	}
 
-		// Preserve quotes if necessary
-		wasQuoted := strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)
-		if wasQuoted && !(strings.HasPrefix(after, `"`) && strings.HasSuffix(after, `"`)) {
-			after = `"` + after + `"`
-		}
+	if !matched {
+		return model.SarifFix{}, fmt.Errorf("line value '%s' does not match any expected values '%s'", normalizedFullLine, strings.Join(altValues, " | "))
+	}
 
-		// Determine replacement range
-		idxs := re.FindStringSubmatchIndex(vuln.LineWithVulnerability)
+	// Preserve quoting if the original value was quoted
+	wasQuoted := strings.HasPrefix(rawValue, `"`) && strings.HasSuffix(rawValue, `"`)
+	if wasQuoted && !(strings.HasPrefix(after, `"`) && strings.HasSuffix(after, `"`)) {
+		after = `"` + after + `"`
+	}
+
+	// Fallback: replace entire value
+	if insertedText == "" {
+		idxs := keyValRegex.FindStringSubmatchIndex(vuln.LineWithVulnerability)
 		if len(idxs) < 6 {
 			return model.SarifFix{}, fmt.Errorf("could not determine exact value location")
 		}
 
 		isFullLine := strings.Contains(after, "=")
-
-		if insertedText == "" {
-			if isFullLine {
-				insertedText = leadingWhitespace + after
-			} else {
-				prefix := vuln.LineWithVulnerability[:idxs[4]]
-				suffix := vuln.LineWithVulnerability[idxs[5]:]
-				insertedText = prefix + after + suffix
-			}
+		if isFullLine {
+			insertedText = leadingWhitespace + after
+		} else {
+			prefix := vuln.LineWithVulnerability[:idxs[4]]
+			suffix := vuln.LineWithVulnerability[idxs[5]:]
+			insertedText = prefix + after + suffix
 		}
-
-		fixStart = model.SarifResourceLocation{
-			Line: vuln.RemediationLocation.Start.Line,
-			Col:  1,
-		}
-		fixEnd = model.SarifResourceLocation{
-			Line: vuln.Line,
-			Col:  len(vuln.LineWithVulnerability) + 1,
-		}
-
-	case "addition":
-		normalizedRemediation := normalizeIndentation(vuln.Remediation, 2)
-
-		insertedLines := strings.Split(normalizedRemediation, "\n")
-
-		var baseIndent string
-
-		nestedInsert := isInsertingInsideNestedBlock(vuln.FileSource, startLocation, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
-
-		baseIndent = determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
-
-		var result []string
-		nestingLevel := 0
-		postIndent := baseIndent
-
-		for _, line := range insertedLines {
-			trimmed := strings.TrimSpace(line)
-
-			if trimmed == "" {
-				// No extra blank line
-				continue
-			}
-
-			isOpeningBrace := strings.HasSuffix(trimmed, "{")
-			isClosingBrace := trimmed == "}"
-
-			// Safely calculate current indentation
-			currentIndent := baseIndent
-
-			if nestingLevel > 0 && !isClosingBrace {
-				currentIndent += strings.Repeat("  ", nestingLevel)
-			}
-
-			// append the base indent after if closing brace
-			if isClosingBrace {
-				postIndent = strings.Repeat("  ", nestingLevel)
-			}
-
-			// if nested insert and not closing brace then add the base indent to the following line
-			if nestedInsert && !isClosingBrace {
-				postIndent = baseIndent
-			}
-
-			// Append the properly indented line
-			result = append(result, currentIndent+trimmed)
-
-			// Adjust nesting AFTER appending
-			if isOpeningBrace {
-				nestingLevel++
-			}
-			if isClosingBrace && nestingLevel > 0 {
-				nestingLevel--
-			}
-		}
-
-		// Build insertedText cleanly
-		insertedText = "\n" + strings.Join(result, "\n")
-
-		// sourceLines := strings.Split(vuln.ResourceSource, "\n")
-		// if determineIfShouldAppendIndent(sourceLines, startLocation, vuln.ResourceLocation, vuln.FileSource) {
-		// 	if nestedInsert {
-		// 		insertedText += "\n" + strings.Repeat(" ", startLocation.Col-1)
-		// 	} else {
-		// 		insertedText += "\n" + strings.Repeat(" ", startLocation.Col)
-		// 	}
-		// } else {
-		insertedText = insertedText + "\n" + postIndent
-		// }
-
-		fixStart = startLocation
-		fixEnd = startLocation
-	case "removal":
-		// Just remove the whole region
-		insertedText = ""
-		fixStart = startLocation
-		fixEnd = endLocation
 	}
 
+	return buildSarifFix(vuln, insertedText, model.SarifResourceLocation{
+		Line: vuln.RemediationLocation.Start.Line,
+		Col:  1,
+	}, model.SarifResourceLocation{
+		Line: vuln.Line,
+		Col:  len(vuln.LineWithVulnerability) + 1,
+	}, vuln.LineWithVulnerability), nil
+}
+
+func buildAdditionFix(vuln model.VulnerableFile, startLocation model.SarifResourceLocation) (model.SarifFix, error) {
+	normalized := normalizeIndentation(vuln.Remediation, 2)
+	lines := strings.Split(normalized, "\n")
+	baseIndent := determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
+	nested := isInsertingInsideNestedBlock(vuln.FileSource, startLocation, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
+
+	var result []string
+	nestingLevel := 0
+	postIndent := baseIndent
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		opening := strings.HasSuffix(trimmed, "{")
+		closing := trimmed == "}"
+
+		indent := baseIndent
+		if nestingLevel > 0 && !closing {
+			indent += strings.Repeat("  ", nestingLevel)
+		}
+		if closing {
+			postIndent = strings.Repeat("  ", nestingLevel)
+		}
+		if nested && !closing {
+			postIndent = baseIndent
+		}
+
+		result = append(result, indent+trimmed)
+
+		if opening {
+			nestingLevel++
+		}
+		if closing && nestingLevel > 0 {
+			nestingLevel--
+		}
+	}
+
+	insertedText := "\n" + strings.Join(result, "\n") + "\n" + postIndent
+	return buildSarifFix(vuln, insertedText, startLocation, startLocation, ""), nil
+}
+
+func buildRemovalFix(vuln model.VulnerableFile, startLocation, endLocation model.SarifResourceLocation) (model.SarifFix, error) {
+	return buildSarifFix(vuln, "", startLocation, endLocation, ""), nil
+}
+
+func buildSarifFix(vuln model.VulnerableFile, insertedText string, startLocation, endLocation model.SarifResourceLocation, originalLine string) model.SarifFix {
 	replacement := model.FixReplacement{
 		DeletedRegion: model.SarifRegion{
-			StartLine:   fixStart.Line,
-			StartColumn: fixStart.Col,
-			EndLine:     fixEnd.Line,
-			EndColumn:   fixEnd.Col,
+			StartLine:   startLocation.Line,
+			StartColumn: startLocation.Col,
+			EndLine:     endLocation.Line,
+			EndColumn:   endLocation.Col,
 		},
 	}
-
 	if insertedText != "" {
 		replacement.InsertedContent = model.FixContent{Text: insertedText}
 	}
 
-	a := model.SarifFix{
+	return model.SarifFix{
 		ArtifactChanges: []model.ArtifactChange{{
 			ArtifactLocation: model.ArtifactLocation{URI: vuln.FileName},
 			Replacements:     []model.FixReplacement{replacement},
@@ -295,121 +205,4 @@ func TransformToSarifFix(vuln model.VulnerableFile, startLocation model.SarifRes
 			Text: fmt.Sprintf("Apply remediation: %s", vuln.Remediation),
 		},
 	}
-
-	return a, nil
-}
-
-func determineActualBaseIndent(fileLines []string, startLine int, blockStartLine int) string {
-	if startLine == 0 {
-		return ""
-	}
-	// Try to find the first non-empty, non-comment line above startLine within block
-	for i := startLine - 1; i >= blockStartLine-1; i-- {
-		line := strings.TrimSpace(fileLines[i])
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
-			continue
-		}
-		return fileLines[i][:len(fileLines[i])-len(strings.TrimLeft(fileLines[i], " \t"))]
-	}
-	return "" // default fallback
-}
-
-// findResourceStartLine searches for where resourceSource starts inside fileSource.
-// Returns the starting line number (1-based), or -1 if not found.
-func findResourceStartLine(fileSource []string, resourceSource []string) int {
-	resourceLines := trimTrailingEmptyLines(resourceSource)
-
-	if len(resourceLines) == 0 {
-		return -1
-	}
-
-	for i := 0; i <= len(fileSource)-len(resourceLines); i++ {
-		match := true
-		for j := 0; j < len(resourceLines); j++ {
-			if strings.TrimSpace(fileSource[i+j]) != strings.TrimSpace(resourceLines[j]) {
-				match = false
-				break
-			}
-		}
-		if match {
-			return i + 1
-		}
-	}
-
-	return -1 // Not found
-}
-
-// trimTrailingEmptyLines removes trailing empty lines from a slice of lines.
-func trimTrailingEmptyLines(lines []string) []string {
-	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
-		lines = lines[:len(lines)-1]
-	}
-	return lines
-}
-
-func normalizeIndentation(input string, spacesPerTab int) string {
-	lines := strings.Split(input, "\n")
-	tabSpaces := strings.Repeat(" ", spacesPerTab)
-
-	for i, line := range lines {
-		// Replace tabs with spaces and trim trailing whitespace
-		line = strings.ReplaceAll(line, "\t", tabSpaces)
-		lines[i] = strings.TrimRight(line, " \t")
-	}
-
-	return strings.Join(lines, "\n")
-}
-
-func normalize(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.ReplaceAll(s, "\r", "")
-	s = strings.ReplaceAll(s, `\"`, `"`)     // Handle escaped quotes
-	s = strings.ReplaceAll(s, `"`, `"`)      // Double safety
-	s = strings.ReplaceAll(s, `“`, `"`)      // Smart quotes (optional)
-	s = strings.ReplaceAll(s, `”`, `"`)      // Smart quotes (optional)
-	s = strings.Join(strings.Fields(s), " ") // normalize extra whitespace
-	s = strings.Trim(s, `"`)
-	return s
-}
-
-func isInsertingInsideNestedBlock(fileLines []string, startLocation model.SarifResourceLocation, blockStartLine int, blockEndLine int) bool {
-	if startLocation.Line <= blockStartLine || startLocation.Line >= blockEndLine {
-		// Inserting outside or exactly at block start/end
-		return false
-	}
-
-	// Read the line we are inserting at
-	if startLocation.Line-1 < 0 || startLocation.Line-1 >= len(fileLines) {
-		return false
-	}
-
-	lineContent := strings.TrimSpace(fileLines[startLocation.Line-1])
-
-	// If inserting into a field or structure inside the block body
-	if lineContent == "" {
-		// blank line — could be inside, assume not nested by blankness
-		return false
-	}
-	if lineContent == "}" {
-		// if right at closing brace, not inside nested body
-		return false
-	}
-
-	// Now, if there is a `{` before or after nearby, you're likely inside a nested structure
-	// (this is heuristic: it covers 99% terraform style)
-
-	// look backwards for a nearby opening `{`
-	for i := startLocation.Line - 2; i >= blockStartLine-1; i-- {
-		if strings.Contains(fileLines[i], "{") {
-			return true // nested structure found
-		}
-		trimmed := strings.TrimSpace(fileLines[i])
-		if trimmed == "" {
-			continue
-		}
-		if trimmed != "}" {
-			break // if it's a field or something else, stop
-		}
-	}
-	return false
 }

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetectTerraformLine(t *testing.T) { //nolint
+func TestTransformToSarifFixE2E(t *testing.T) { //nolint
 	testCases := []struct {
 		expected      model.SarifFix
 		vuln          model.VulnerableFile
@@ -85,6 +85,203 @@ func TestDetectTerraformLine(t *testing.T) { //nolint
 			v, err := TransformToSarifFix(testCase.vuln, testCase.startLocation, testCase.endLocation)
 			assert.Nil(t, err)
 			require.Equal(t, testCase.expected, v)
+		})
+	}
+}
+
+func TestTransformToSarifFix_Addition(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:        "main.tf",
+		RemediationType: "addition",
+		Remediation:     `tags = {\n  Environment = "dev"\n}`,
+		FileSource: []string{
+			"resource \"aws_s3_bucket\" \"bucket\" {",
+			"  bucket = \"my-bucket\"",
+			"}",
+		},
+		BlockLocation: model.ResourceLocation{Start: model.ResourceLine{Line: 1}, End: model.ResourceLine{Line: 3}},
+	}
+	start := model.SarifResourceLocation{Line: 2, Col: 3}
+	fix, err := TransformToSarifFix(vuln, start, start)
+	require.NoError(t, err)
+	require.Contains(t, fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text, "Environment")
+}
+
+func TestTransformToSarifFix_Removal(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:        "main.tf",
+		RemediationType: "removal",
+		FileSource: []string{
+			"resource \"aws_s3_bucket\" \"bucket\" {",
+			"  acl = \"public-read\"",
+			"}",
+		},
+	}
+	start := model.SarifResourceLocation{Line: 2, Col: 3}
+	end := model.SarifResourceLocation{Line: 2, Col: 25}
+	fix, err := TransformToSarifFix(vuln, start, end)
+	require.NoError(t, err)
+	require.Equal(t, "", fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text)
+}
+
+func TestTransformToSarifFix_Replacement(t *testing.T) {
+	tests := []struct {
+		name     string
+		vuln     model.VulnerableFile
+		start    model.SarifResourceLocation
+		end      model.SarifResourceLocation
+		wantErr  bool
+		expected string // substring expected in the inserted content
+	}{
+		{
+			name: "simple key-value replacement",
+			vuln: model.VulnerableFile{
+				FileName:              "main.tf",
+				RemediationType:       "replacement",
+				Remediation:           `{"before": "acl = \"authenticated-read\"", "after": "private"}`,
+				LineWithVulnerability: `  acl = "authenticated-read"`,
+				RemediationLocation:   model.ResourceLocation{Start: model.ResourceLine{Line: 3, Col: 3}},
+				Line:                  3,
+				FileSource:            []string{"resource \"aws_s3_bucket\" \"bucket\" {", "  bucket = \"my-bucket\"", "  acl = \"authenticated-read\"", "}"},
+				BlockLocation:         model.ResourceLocation{Start: model.ResourceLine{Line: 1}, End: model.ResourceLine{Line: 4}},
+			},
+			start:    model.SarifResourceLocation{Line: 3, Col: 3},
+			end:      model.SarifResourceLocation{Line: 3, Col: 30},
+			wantErr:  false,
+			expected: "private",
+		},
+		{
+			name: "list value without quotes",
+			vuln: model.VulnerableFile{
+				FileName:              "main.tf",
+				RemediationType:       "replacement",
+				Remediation:           `{"before": "features = [PublicAccess]", "after": "PrivateLink"}`,
+				LineWithVulnerability: `  features = [PublicAccess, OtherFeature]`,
+				RemediationLocation:   model.ResourceLocation{Start: model.ResourceLine{Line: 4, Col: 3}},
+				Line:                  4,
+				FileSource: []string{
+					"resource \"example\" \"test\" {",
+					"  name     = \"example\"",
+					"  region   = \"us-east-1\"",
+					"  features = [PublicAccess, OtherFeature]",
+					"}",
+				},
+				BlockLocation: model.ResourceLocation{Start: model.ResourceLine{Line: 1}, End: model.ResourceLine{Line: 5}},
+			},
+			start:    model.SarifResourceLocation{Line: 4, Col: 3},
+			end:      model.SarifResourceLocation{Line: 4, Col: 60},
+			wantErr:  false,
+			expected: "PrivateLink",
+		},
+		{
+			name: "replace multiple matching list items",
+			vuln: model.VulnerableFile{
+				FileName:              "main.tf",
+				RemediationType:       "replacement",
+				Remediation:           `{"before": "access = [\"PublicNetworkAccess\"]", "after": "PrivateLink"}`,
+				LineWithVulnerability: `  access = ["PublicNetworkAccess", "PublicNetworkAccess"]`,
+				RemediationLocation:   model.ResourceLocation{Start: model.ResourceLine{Line: 4, Col: 3}},
+				Line:                  4,
+				FileSource: []string{
+					"resource \"azurerm_example\" \"test\" {",
+					"  name = \"multi\"",
+					"  location = \"eastus\"",
+					"  access = [\"PublicNetworkAccess\", \"PublicNetworkAccess\"]",
+					"}",
+				},
+				BlockLocation: model.ResourceLocation{Start: model.ResourceLine{Line: 1}, End: model.ResourceLine{Line: 5}},
+			},
+			start:    model.SarifResourceLocation{Line: 4, Col: 3},
+			end:      model.SarifResourceLocation{Line: 4, Col: 60},
+			wantErr:  false,
+			expected: "PrivateLink",
+		},
+		{
+			name: "line with inline comment",
+			vuln: model.VulnerableFile{
+				FileName:              "main.tf",
+				RemediationType:       "replacement",
+				Remediation:           `{"before": "acl = \"authenticated-read\"", "after": "private"}`,
+				LineWithVulnerability: `  acl = "authenticated-read" # managed by security team`,
+				RemediationLocation:   model.ResourceLocation{Start: model.ResourceLine{Line: 3, Col: 3}},
+				Line:                  3,
+				FileSource: []string{
+					"resource \"aws_s3_bucket\" \"bucket\" {",
+					"  bucket = \"my-bucket\"",
+					"  acl = \"authenticated-read\" # managed by security team",
+					"}",
+				},
+				BlockLocation: model.ResourceLocation{Start: model.ResourceLine{Line: 1}, End: model.ResourceLine{Line: 4}},
+			},
+			start:    model.SarifResourceLocation{Line: 3, Col: 3},
+			end:      model.SarifResourceLocation{Line: 3, Col: 80},
+			wantErr:  false,
+			expected: "private",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fix, err := TransformToSarifFix(tt.vuln, tt.start, tt.end)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTransformToSarifFix_AddToEmptyBlock(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:        "main.tf",
+		RemediationType: "addition",
+		Remediation:     `tags = {\n  Environment = "prod"\n}`,
+		FileSource: []string{
+			"resource \"aws_s3_bucket\" \"example\" {",
+			"  tags = {}",
+			"}",
+		},
+		BlockLocation: model.ResourceLocation{Start: model.ResourceLine{Line: 1}, End: model.ResourceLine{Line: 3}},
+	}
+	start := model.SarifResourceLocation{Line: 2, Col: 10}
+	fix, err := TransformToSarifFix(vuln, start, start)
+	require.NoError(t, err)
+	require.Contains(t, fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text, "Environment")
+}
+
+func TestTransformToSarifFix_Removal_QuotedUnquoted(t *testing.T) {
+	tests := []model.VulnerableFile{
+		{
+			FileName:        "main.tf",
+			RemediationType: "removal",
+			Line:            2,
+			FileSource: []string{
+				"resource \"aws_s3_bucket\" \"bucket\" {",
+				"  enabled = true",
+				"}",
+			},
+		},
+		{
+			FileName:        "main.tf",
+			RemediationType: "removal",
+			Line:            2,
+			FileSource: []string{
+				"resource \"aws_s3_bucket\" \"bucket\" {",
+				"  enabled = \"true\"",
+				"}",
+			},
+		},
+	}
+
+	for i, vuln := range tests {
+		start := model.SarifResourceLocation{Line: 2, Col: 3}
+		end := model.SarifResourceLocation{Line: 2, Col: 20}
+		t.Run(fmt.Sprintf("removal_case_%d", i), func(t *testing.T) {
+			fix, err := TransformToSarifFix(vuln, start, end)
+			require.NoError(t, err)
+			require.Equal(t, "", fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text)
 		})
 	}
 }

--- a/pkg/report/remediations/utilities.go
+++ b/pkg/report/remediations/utilities.go
@@ -1,0 +1,105 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/Checkmarx/kics/pkg/model"
+)
+
+func parseAlternatives(before string) []string {
+	if strings.Contains(before, " or ") {
+		parts := strings.Split(before, " or ")
+		result := make([]string, 0, len(parts))
+		for _, part := range parts {
+			_, val := splitKeyValue(part)
+			result = append(result, normalizeListItem(val))
+		}
+		return result
+	}
+	_, val := splitKeyValue(before)
+	return []string{normalizeListItem(val)}
+}
+
+func normalizeListItem(val string) string {
+	val = strings.TrimSpace(val)
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		val = val[1 : len(val)-1]
+		val = strings.TrimSpace(val)
+	}
+	if strings.HasPrefix(val, `"`) && strings.HasSuffix(val, `"`) {
+		val = val[1 : len(val)-1]
+	}
+	return normalize(val)
+}
+func splitKeyValue(expr string) (string, string) {
+	parts := strings.SplitN(expr, "=", 2)
+	if len(parts) == 2 {
+		return normalize(strings.TrimSpace(parts[0])), normalize(strings.TrimSpace(parts[1]))
+	}
+	return "", normalize(expr)
+}
+
+func determineActualBaseIndent(fileLines []string, startLine int, blockStartLine int) string {
+	if startLine == 0 {
+		return ""
+	}
+	for i := startLine - 1; i >= blockStartLine-1; i-- {
+		line := strings.TrimSpace(fileLines[i])
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
+			continue
+		}
+		return fileLines[i][:len(fileLines[i])-len(strings.TrimLeft(fileLines[i], " \t"))]
+	}
+	return ""
+}
+
+func normalizeIndentation(input string, spacesPerTab int) string {
+	lines := strings.Split(input, "\n")
+	tabSpaces := strings.Repeat(" ", spacesPerTab)
+
+	for i, line := range lines {
+		line = strings.ReplaceAll(line, "\t", tabSpaces)
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func normalize(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, `\"`, `"`)
+	s = strings.ReplaceAll(s, `“`, `"`)
+	s = strings.ReplaceAll(s, `”`, `"`)
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.Trim(s, `"`)
+	return s
+}
+
+func isInsertingInsideNestedBlock(fileLines []string, startLocation model.SarifResourceLocation, blockStartLine, blockEndLine int) bool {
+	if startLocation.Line <= blockStartLine || startLocation.Line >= blockEndLine {
+		return false
+	}
+
+	if startLocation.Line-1 < 0 || startLocation.Line-1 >= len(fileLines) {
+		return false
+	}
+
+	lineContent := strings.TrimSpace(fileLines[startLocation.Line-1])
+	if lineContent == "" || lineContent == "}" {
+		return false
+	}
+
+	for i := startLocation.Line - 2; i >= blockStartLine-1; i-- {
+		if strings.Contains(fileLines[i], "{") {
+			return true
+		}
+		trimmed := strings.TrimSpace(fileLines[i])
+		if trimmed == "" {
+			continue
+		}
+		if trimmed != "}" {
+			break
+		}
+	}
+	return false
+}


### PR DESCRIPTION
There are a few motivations for the changes here:

1. Reduce Function Complexity- break up the large functions that were doing everything
2. Centralize Constant Return Values- reduce some duplication in the values being returned that were constanst (undetected, empty, etc)
3. Cleanup Inline Comments- outdated from previous work
4. Log Errors Using Logger, Not fmt.Printf
5. Naming improvements (my white whale 🐋)
6. Handle case where type assertions may panic with unexpected input
7. Refactor the three main RemediationType cases into their own clearly named helpers
8. Split Block-Style and List-Style Matching
9. Add missing tests for edge cases