### PR TITLE
[K9VULN-4961] Make remediations gateable

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -31,7 +31,7 @@ import (
 
 const divisor = float32(100000)
 
-var reportGenerators = map[string]func(path, filename string, body interface{}, sciInfo model.SCIInfo) error{
+var reportGenerators = map[string]func(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error{
 	"json":        report.PrintJSONReport,
 	"sarif":       report.PrintSarifReport,
 	"html":        report.PrintHTMLReport,
@@ -104,7 +104,7 @@ func FileAnalyzer(path string) (string, error) {
 }
 
 // GenerateReport execute each report function to generate report
-func GenerateReport(path, filename string, body interface{}, formats []string, proBarBuilder progress.PbBuilder, sciInfo model.SCIInfo) error {
+func GenerateReport(path, filename string, body interface{}, formats []string, proBarBuilder progress.PbBuilder, sciInfo model.SCIInfo, includeRemediations bool) error {
 	log.Debug().Msgf("helpers.GenerateReport()")
 	metrics.Metric.Start("generate_report")
 
@@ -116,7 +116,7 @@ func GenerateReport(path, filename string, body interface{}, formats []string, p
 
 	for _, format := range formats {
 		format = strings.ToLower(format)
-		if err = reportGenerators[format](path, filename, body, sciInfo); err != nil {
+		if err = reportGenerators[format](path, filename, body, sciInfo, includeRemediations); err != nil {
 			log.Error().Msgf("Failed to generate %s report", format)
 			break
 		}

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -177,7 +177,7 @@ func TestHelpers_GenerateReport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := GenerateReport(tt.args.path, tt.args.filename, tt.args.body, tt.args.formats, progress.PbBuilder{}, model.SCIInfo{})
+			err := GenerateReport(tt.args.path, tt.args.filename, tt.args.body, tt.args.formats, progress.PbBuilder{}, model.SCIInfo{}, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateReport() = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/kics.go
+++ b/kics.go
@@ -15,11 +15,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string) {
+func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo, includeRemediations bool) (scan.ScanMetadata, string) {
 	params := scan.GetDefaultParameters(outputPath)
 	params.Path = inputPaths
 	params.OutputPath = outputPath
 	params.SCIInfo = sciInfo
+	params.IncludeRemediations = includeRemediations
 	metadata, err := console.ExecuteScan(params)
 	if err != nil {
 		log.Fatal().Int64(

--- a/pkg/report/asff.go
+++ b/pkg/report/asff.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintASFFReport prints the ASFF report in the given path and filename with the given body
-func PrintASFFReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintASFFReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasPrefix(filename, "asff-") {
 		filename = "asff-" + filename
 	}

--- a/pkg/report/asff_test.go
+++ b/pkg/report/asff_test.go
@@ -47,7 +47,7 @@ func TestPrintASFFReport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := PrintASFFReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err := PrintASFFReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 
 			require.FileExists(t, filepath.Join(test.caseTest.path, "asff-"+test.caseTest.filename+".json"))

--- a/pkg/report/code_climate.go
+++ b/pkg/report/code_climate.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintCodeClimateReport prints the code climate report in the given path and filename with the given body
-func PrintCodeClimateReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintCodeClimateReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasPrefix(filename, "codeclimate") {
 		filename = "codeclimate-" + filename
 	}

--- a/pkg/report/code_climate_test.go
+++ b/pkg/report/code_climate_test.go
@@ -47,7 +47,7 @@ func TestPrintCodeClimateReport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := PrintCodeClimateReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err := PrintCodeClimateReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 
 			require.FileExists(t, filepath.Join(test.caseTest.path, "codeclimate-"+test.caseTest.filename+".json"))

--- a/pkg/report/csv.go
+++ b/pkg/report/csv.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintCSVReport prints the CSV report in the given path and filename with the given body
-func PrintCSVReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintCSVReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasSuffix(filename, ".csv") {
 		filename += ".csv"
 	}

--- a/pkg/report/csv_test.go
+++ b/pkg/report/csv_test.go
@@ -47,7 +47,7 @@ func TestPrintCSVReport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := PrintCSVReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err := PrintCSVReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 
 			require.FileExists(t, filepath.Join(test.caseTest.path, test.caseTest.filename+".csv"))

--- a/pkg/report/cyclonedx.go
+++ b/pkg/report/cyclonedx.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintCycloneDxReport prints the CycloneDX report in the given path and filename with the given body
-func PrintCycloneDxReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintCycloneDxReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	filePaths := make(map[string]string)
 
 	if !strings.HasPrefix(filename, "cyclonedx-") {

--- a/pkg/report/cyclonedx_test.go
+++ b/pkg/report/cyclonedx_test.go
@@ -61,7 +61,7 @@ func TestPrintCycloneDxReport(t *testing.T) {
 			if err := os.MkdirAll(tt.args.path, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			if err := PrintCycloneDxReport(tt.args.path, tt.args.filename, tt.args.body, model.SCIInfo{}); (err != nil) != tt.wantErr {
+			if err := PrintCycloneDxReport(tt.args.path, tt.args.filename, tt.args.body, model.SCIInfo{}, false); (err != nil) != tt.wantErr {
 				t.Errorf("PrintCycloneDxReport() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			require.FileExists(t, filepath.Join(tt.args.path, "cyclonedx-"+tt.args.filename+".xml"))

--- a/pkg/report/gitlab_sast.go
+++ b/pkg/report/gitlab_sast.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintGitlabSASTReport creates a report file on sarif format
-func PrintGitlabSASTReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintGitlabSASTReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	filename = strings.ReplaceAll(filename, ".glsast", "")
 	if !strings.HasSuffix(filename, jsonExtension) {
 		filename += jsonExtension

--- a/pkg/report/gitlab_sast_test.go
+++ b/pkg/report/gitlab_sast_test.go
@@ -48,7 +48,7 @@ func TestPrintGitlabSASTReport(t *testing.T) {
 			if err := os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			err := PrintGitlabSASTReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err := PrintGitlabSASTReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(test.caseTest.path, "gl-sast-"+test.caseTest.filename+".json"))
 			os.RemoveAll(test.caseTest.path)

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -83,7 +83,7 @@ func getVersion() string {
 }
 
 // PrintHTMLReport creates a report file on HTML format
-func PrintHTMLReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintHTMLReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasSuffix(filename, ".html") {
 		filename += ".html"
 	}

--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -50,7 +50,7 @@ func TestPrintHTMLReport(t *testing.T) {
 			if err := os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			err := PrintHTMLReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err := PrintHTMLReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(test.caseTest.path, test.caseTest.filename+".html"))
 			htmlString, err := os.ReadFile(filepath.Join(test.caseTest.path, test.caseTest.filename+".html"))

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -13,7 +13,7 @@ import (
 const jsonExtension = ".json"
 
 // PrintJSONReport prints on JSON file the summary results
-func PrintJSONReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintJSONReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if body != "" {
 		summary, err := getSummary(body)
 		if err != nil {

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -57,7 +57,7 @@ func TestPrintJSONReport(t *testing.T) {
 			if err = os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			err = PrintJSONReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err = PrintJSONReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(test.caseTest.path, test.caseTest.filename+".json"))
 			var jsonResult []byte

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintJUnitReport prints the JUnit report in the given path and filename with the given body
-func PrintJUnitReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintJUnitReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasPrefix(filename, "junit-") {
 		filename = "junit-" + filename
 	}

--- a/pkg/report/junit_test.go
+++ b/pkg/report/junit_test.go
@@ -48,7 +48,7 @@ func TestPrintJUnitReport(t *testing.T) {
 			if err := os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			err := PrintJUnitReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{})
+			err := PrintJUnitReport(test.caseTest.path, test.caseTest.filename, test.caseTest.summary, model.SCIInfo{}, false)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(test.caseTest.path, "junit-"+test.caseTest.filename+".xml"))
 			os.RemoveAll(test.caseTest.path)

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -214,7 +214,7 @@ type SarifRun struct {
 
 // SarifReport represents a usable sarif report reference
 type SarifReport interface {
-	BuildSarifIssue(issue *model.QueryResult, sciInfo model.SCIInfo) string
+	BuildSarifIssue(issue *model.QueryResult, sciInfo model.SCIInfo, includeRemediations bool) string
 	RebuildTaxonomies(cwes []string, guids map[string]string)
 	GetGUIDFromRelationships(idx int, cweID string) string
 	AddTags(summary *model.Summary, diffAware *model.DiffAware) error
@@ -599,7 +599,7 @@ func (sr *sarifReport) RebuildTaxonomies(cwes []string, guids map[string]string)
 }
 
 // BuildSarifIssue creates a new entries in Results (one for each file) and new entry in Rules and Taxonomy if necessary
-func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.SCIInfo) string {
+func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.SCIInfo, includeRemediations bool) string {
 	if len(issue.Files) > 0 {
 		metadata := ruleMetadata{
 			queryID:          issue.QueryID,
@@ -704,22 +704,24 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 					DatadogFingerprint: GetDatadogFingerprintHash(sciInfo, absoluteFilePath, line, issue.QueryID),
 				},
 			}
-			if vulnerability.Remediation != "" && vulnerability.RemediationType != "" {
-				sarifFix, err := remediationsHelper.TransformToSarifFix(
-					vulnerability,
-					remediationStartLocation,
-					remediationEndLocation,
-				)
-				if err != nil {
-					// we do not want to fail the whole process if we cannot transform the fix
-					// so we just log the error and continue
-					log.Err(err).Msgf("failed to transform to sarif fix: %v", err)
-				} else {
-					// we want the location displayed in the UI to properly highlight the remediation
-					result.ResultLocations[0].PhysicalLocation.Region.StartLine = remediationStartLocation.Line
-					result.ResultLocations[0].PhysicalLocation.Region.EndLine = remediationEndLocation.Line
+			if includeRemediations {
+				if vulnerability.Remediation != "" && vulnerability.RemediationType != "" {
+					sarifFix, err := remediationsHelper.TransformToSarifFix(
+						vulnerability,
+						remediationStartLocation,
+						remediationEndLocation,
+					)
+					if err != nil {
+						// we do not want to fail the whole process if we cannot transform the fix
+						// so we just log the error and continue
+						log.Err(err).Msgf("failed to transform to sarif fix: %v", err)
+					} else {
+						// we want the location displayed in the UI to properly highlight the remediation
+						result.ResultLocations[0].PhysicalLocation.Region.StartLine = remediationStartLocation.Line
+						result.ResultLocations[0].PhysicalLocation.Region.EndLine = remediationEndLocation.Line
 
-					result.ResultFixes = append(result.ResultFixes, sarifFix)
+						result.ResultFixes = append(result.ResultFixes, sarifFix)
+					}
 				}
 			}
 			sr.Runs[0].Results = append(sr.Runs[0].Results, result)

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -375,7 +375,7 @@ func TestBuildSarifIssue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NewSarifReport().(*sarifReport)
 			for _, vq := range tt.vq {
-				result.BuildSarifIssue(&vq, model.SCIInfo{})
+				result.BuildSarifIssue(&vq, model.SCIInfo{}, true)
 			}
 			require.Equal(t, len(tt.want.Runs[0].Results), len(result.Runs[0].Results))
 			require.Equal(t, len(tt.want.Runs[0].Tool.Driver.Rules), len(result.Runs[0].Tool.Driver.Rules))

--- a/pkg/report/pdf.go
+++ b/pkg/report/pdf.go
@@ -292,7 +292,7 @@ func createFooterArea(m pdf.Maroto) {
 }
 
 // PrintPdfReport creates a report file on the PDF format
-func PrintPdfReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintPdfReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	startTime := time.Now()
 	log.Info().Msg("Started generating pdf report")
 

--- a/pkg/report/pdf_test.go
+++ b/pkg/report/pdf_test.go
@@ -47,7 +47,7 @@ func TestPrintPdfReport(t *testing.T) {
 			if err := os.MkdirAll(test.caseTest.path, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			err := PrintPdfReport(test.caseTest.path, test.caseTest.filename, &test.caseTest.summary, model.SCIInfo{})
+			err := PrintPdfReport(test.caseTest.path, test.caseTest.filename, &test.caseTest.summary, model.SCIInfo{}, false)
 			checkFileExists(t, err, &test, "pdf")
 			os.RemoveAll(test.caseTest.path)
 		})

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintSarifReport creates a report file on sarif format, fetching the ID and GUID from relationships to be inputted to taxonomies field
-func PrintSarifReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintSarifReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasSuffix(filename, ".sarif") {
 		filename += ".sarif"
 	}
@@ -27,7 +27,7 @@ func PrintSarifReport(path, filename string, body interface{}, sciInfo model.SCI
 		auxID := []string{}
 		auxGUID := map[string]string{}
 		for idx := range summary.Queries {
-			x := sarifReport.BuildSarifIssue(&summary.Queries[idx], sciInfo)
+			x := sarifReport.BuildSarifIssue(&summary.Queries[idx], sciInfo, includeRemediations)
 			if x != "" {
 				auxID = append(auxID, x)
 				guid := sarifReport.GetGUIDFromRelationships(idx, x)

--- a/pkg/report/sonarqube.go
+++ b/pkg/report/sonarqube.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrintSonarQubeReport prints the SonarQube report in the given path and filename with the given body
-func PrintSonarQubeReport(path, filename string, body interface{}, sciInfo model.SCIInfo) error {
+func PrintSonarQubeReport(path, filename string, body interface{}, sciInfo model.SCIInfo, includeRemediations bool) error {
 	if !strings.HasSuffix(filename, ".json") {
 		filename += ".json"
 	}

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -58,6 +58,7 @@ type Parameters struct {
 	KicsComputeNewSimID         bool
 	PreAnalysisExcludePaths     []string
 	SCIInfo                     model.SCIInfo
+	IncludeRemediations         bool
 }
 
 // Client represents a scan client
@@ -114,6 +115,7 @@ func GetDefaultParameters(rootPath string) *Parameters {
 		UseOldSeverities:            false,
 		MaxResolverDepth:            15,
 		ExcludePlatform:             []string{""},
+		IncludeRemediations:         false,
 	}
 }
 

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -89,10 +89,11 @@ func (c *Client) resolveOutputs(
 		summary, c.ScanParams.ReportFormats,
 		proBarBuilder,
 		c.ScanParams.SCIInfo,
+		c.ScanParams.IncludeRemediations,
 	)
 }
 
-func printOutput(outputPath, filename string, body interface{}, formats []string, proBarBuilder progress.PbBuilder, sciInfo model.SCIInfo) error {
+func printOutput(outputPath, filename string, body interface{}, formats []string, proBarBuilder progress.PbBuilder, sciInfo model.SCIInfo, includeRemediations bool) error {
 	log.Debug().Msg("console.printOutput()")
 	if outputPath == "" {
 		return nil
@@ -103,7 +104,7 @@ func printOutput(outputPath, filename string, body interface{}, formats []string
 
 	log.Debug().Msgf("Output formats provided [%v]", strings.Join(formats, ","))
 	log.Debug().Msgf("SCIInfo: %v", sciInfo)
-	err := consoleHelpers.GenerateReport(outputPath, filename, body, formats, proBarBuilder, sciInfo)
+	err := consoleHelpers.GenerateReport(outputPath, filename, body, formats, proBarBuilder, sciInfo, includeRemediations)
 
 	return err
 }

--- a/pkg/scan/post_scan_test.go
+++ b/pkg/scan/post_scan_test.go
@@ -281,7 +281,7 @@ func Test_PrintOutput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := printOutput(tt.outputPath, tt.filename, tt.body, tt.formats, tt.proBarBuilder, model.SCIInfo{})
+			err := printOutput(tt.outputPath, tt.filename, tt.body, tt.formats, tt.proBarBuilder, model.SCIInfo{}, true)
 			os.Remove(filepath.Join("..", "..", tt.filename+".json"))
 			require.NoError(t, err)
 		})


### PR DESCRIPTION
We want to make remediations in SARIF a gateable feature. This PR adds the logic to wire up the associated boolean flag into the scan execution and controls whether we populate the fixes into the SARIF or not.