### PR TITLE
[Datadog] Fix Infrastructure as Code violation

### DIFF
--- a/assets/queries/terraform/aws/redis_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/redis_disabled/test/negative.tf
@@ -4,5 +4,7 @@ resource "aws_elasticache_cluster" "negative1" {
   engine               = "redis"
   node_type            = "cache.m4.large"
   num_cache_nodes      = 2
+  
+  snapshot_retention_limit = 5
   port                 = 11211
 }


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [ElastiCache Redis Cluster Without Backup](https://dd-6517c55c3eb5bd340e62a2b37a04b720.datad0g.com/ci/code-analysis/github.com%2Fdatadog%2Fkics/main/f4dfaa726aae0c86c2f02b3b3111fe07ef1989af/?staticAnalysisId=)