### PR TITLE
[K9VULN-5006] Add AMI owner missing rule

### DIFF
--- a/assets/queries/terraform/aws/ami_owner_missing/metadata.json
+++ b/assets/queries/terraform/aws/ami_owner_missing/metadata.json
@@ -1,0 +1,12 @@
+{
+  "id": "f317c3c2-58e5-4aa7-bb8e-3a7f6bcd274a",
+  "queryName": "AMI Most Recent Without Owner or Filter",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "Avoid using the aws_ami data source with most_recent = true unless an 'owners' attribute or a specific filter like 'owner-id', 'owner-alias', or 'image-id' is set. Omitting these may result in unintended AMIs being selected.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami",
+  "platform": "Terraform",
+  "descriptionID": "f317c3c2",
+  "cloudProvider": "aws",
+  "cwe": "346"
+}

--- a/assets/queries/terraform/aws/ami_owner_missing/query.rego
+++ b/assets/queries/terraform/aws/ami_owner_missing/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+CxPolicy[result] {
+    input.document[i].data["aws_ami"][name].most_recent == true
+    not has_valid_owner_or_filter(input.document[i].data["aws_ami"][name])
+
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": "data.aws_ami",
+        "resourceName": tf_lib.get_specific_resource_name(input.document[i].data.aws_ami[name], "aws_ami", name),
+        "searchKey": sprintf("data.aws_ami[%s].most_recent", [name]),
+        "issueType": "MissingValue",
+        "keyExpectedValue": "Must define 'owners' or a filter with 'owner-id', 'owner-alias', or 'image-id' when most_recent = true",
+        "keyActualValue": "'most_recent = true' without owner or valid filter",
+        "searchLine": common_lib.build_search_line(["data", "aws_ami", name, "most_recent"], [])
+    }
+}
+
+has_valid_owner_or_filter(resource) {
+    resource.owners != null
+}
+
+has_valid_owner_or_filter(resource) {
+    f := resource.filter[_]
+    f.name != null
+    check_valid_filters(f.name)
+}
+
+check_valid_filters(p) {
+	filters = {
+        "owner-id",
+        "owner-alias",
+        "image-id"
+    }
+	filters[p]
+}

--- a/assets/queries/terraform/aws/ami_owner_missing/test/negative.tf
+++ b/assets/queries/terraform/aws/ami_owner_missing/test/negative.tf
@@ -1,0 +1,56 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+  filter {
+    name   = "owner-id"
+    values = ["099720109477"]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+  owners = ["099720109477"] // Canonical
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "image-id"
+    values = ["ami-12345"]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-1234"]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] // Canonical
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+}

--- a/assets/queries/terraform/aws/ami_owner_missing/test/positive.tf
+++ b/assets/queries/terraform/aws/ami_owner_missing/test/positive.tf
@@ -1,0 +1,9 @@
+# non-compliant
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+}

--- a/assets/queries/terraform/aws/ami_owner_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ami_owner_missing/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "AMI Most Recent Without Owner or Filter",
+    "severity": "HIGH",
+    "line": 3
+  }
+]


### PR DESCRIPTION
As part of evaluating the existing SAST Terraform rules we identified that one was missing from the existing KICS coverage.
The missing rule is [ami-missing-owners](https://app.datadoghq.com/ci/code-analysis/static-analysis/default-rulesets/terraform-aws?currentTab=overview&ruleName=ami-missing-owners).
This PR adds the relevant rule and examples.