### PR TITLE
[K9VULN-5251] Handle jsonencode in policy statements

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -64,22 +64,32 @@ getProtocolList(protocol) = protocols {
 
 # Checks if any principal are allowed in a policy
 anyPrincipal(statement) {
-	contains(statement.Principal, "*")
+  # Case: Principal = "*"
+  statement.Principal == "*"
 }
 
 anyPrincipal(statement) {
-	contains(statement.Principal[_], "*")
+  # Case: Principal = {"AWS": "*"}
+  is_string(statement.Principal.AWS)
+  statement.Principal.AWS == "*"
 }
 
 anyPrincipal(statement) {
-	is_string(statement.Principal.AWS)
-	contains(statement.Principal.AWS, "*")
+  # Case: Principal = {"AWS": ["*"]}
+  is_array(statement.Principal.AWS)
+  "*" == statement.Principal.AWS[_]
 }
 
 anyPrincipal(statement) {
-	is_array(statement.Principal.AWS)
-	some i
-	contains(statement.Principal.AWS[i], "*")
+  # Case: Principal = {"Service": "*"}  (uncommon, but valid)
+  is_string(statement.Principal.Service)
+  statement.Principal.Service == "*"
+}
+
+anyPrincipal(statement) {
+  # Case: Principal = {"Service": ["*"]}
+  is_array(statement.Principal.Service)
+  "*" == statement.Principal.Service[_]
 }
 
 getSpecInfo(resource) = specInfo { # this one can be also used for the result

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -43,10 +43,13 @@ CxPolicy[result] {
 }
 
 access_to_any_principal(policyValue) {
-	policy := common_lib.json_unmarshal(policyValue)
-	st := common_lib.get_statement(policy)
-	statement := st[_]
+  policy := common_lib.json_unmarshal(policyValue)
 
-	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+  st := common_lib.get_statement(policy)
+  statement := st[_]
+
+  common_lib.is_allow_effect(statement)
+  tf_lib.anyPrincipal(statement)
+
+  keys := [k | k := key; _ := policy[k]]
 }

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive3.tf
@@ -1,0 +1,61 @@
+resource "aws_s3_bucket" "this" {
+  bucket = "my_tf_test_bucket"
+  tags = {
+    Name = "My bucket"
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      # When used directly as a Cloudfront origin.
+      Effect = "Allow"
+      Action = "s3:GetObject"
+      Principal = {
+        Service = "cloudfront.amazonaws.com"
+      }
+      Resource = [
+        "${aws_s3_bucket.this.arn}/*",
+      ]
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.this.arn
+        }
+      }
+      },
+      {
+        # Admin access for policy updates, etc.
+        Effect = "Allow"
+        Action = "s3:*"
+        Principal = {
+          AWS = [
+            data.aws_caller_identity.current.id,
+          ]
+        }
+        Resource = [
+          "${aws_s3_bucket.this.arn}/*",
+        ]
+      },
+      {
+        # Delegate access to the access point.
+        Effect = "Allow"
+        Action = "*"
+        Principal = {
+          AWS = [
+            "*"
+          ]
+        }
+        Resource = [
+          aws_s3_bucket.this.arn,
+          "${aws_s3_bucket.this.arn}/*",
+        ]
+        Condition = {
+          "StringEquals" = {
+            "s3:DataAccessPointAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+    }]
+  })
+}

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
@@ -10,5 +10,11 @@
     "severity": "CRITICAL",
     "line": 12,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "S3 Bucket Access to Any Principal",
+    "severity": "CRITICAL",
+    "line": 10,
+    "fileName": "positive3.tf"
   }
 ]


### PR DESCRIPTION
As part of investigating the diff between Checkov and our Iac Scanning results there are 7 rules which aren't generating violations.
This PR addresses one of the rules:

Checkov ID | Description | KICS ID
-- | -- | --
CKV_AWS_70 | Ensure S3 bucket does not allow an action with any Principal | 7af43613-6bb9-4a0e-8c4d-1314b799425e



The problem is that our rego logic wasn't setup to handle jsonencoded values like the one present in the cloud-inventory file that is violating in the checkov results.
The fix ended up being more complicated however because I need to basically parse and convert the hcl into the AST objects to pass to the rego execution myself as well as handle variable values because they would break the json decoding logic. 
This PR therefore uses the hclsyntax and hclparse libraries to pre-process and extract any use of the jsconencode function as well as updates the rego functions that unmarshal json to properly handle this.