### PR TITLE
[K9VULN-5254] Fix GCP DNSSec rule

### DIFF
--- a/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive1.tf
+++ b/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive1.tf
@@ -1,0 +1,40 @@
+resource "google_dns_managed_zone" "target" {
+  name        = "postgres-eu1-prod-dog"
+  dns_name    = "postgres.eu1.prod.dog."
+  description = "delegated from google cloud dns"
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to DNSSEC, since these resourceswere changed
+      # outside of this terraform configuration
+      dnssec_config,
+    ]
+  }
+
+}
+
+data "google_dns_managed_zone" "source" {
+  name = "eu1-prod-dog"
+}
+
+resource "google_dns_record_set" "delegate" {
+  name         = "postgres.eu1.prod.dog."
+  managed_zone = google_dns_managed_zone.target.name
+
+  type = "NS"
+  ttl  = 21600
+
+  rrdatas = google_dns_managed_zone.target.name_servers
+}
+
+// Override the default SOA record for the zone to lower the negative ttl on NameErrors
+// NXDOMAINS and NODATA responses are cached by cloud resolvers for min(soa.minimum_ttl, soa.ttl).
+resource "google_dns_record_set" "soa_override" {
+  name         = google_dns_managed_zone.target.dns_name
+  managed_zone = google_dns_managed_zone.target.name
+
+  type = "SOA"
+  ttl  = 300
+
+  rrdatas = ["${google_dns_managed_zone.target.name_servers[0]} cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300"]
+}

--- a/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive1.tf
+++ b/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive1.tf
@@ -5,7 +5,7 @@ resource "google_dns_managed_zone" "target" {
 
   lifecycle {
     ignore_changes = [
-      # Ignore changes to DNSSEC, since these resourceswere changed
+      # Ignore changes to DNSSEC, since these resources were changed
       # outside of this terraform configuration
       dnssec_config,
     ]

--- a/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive2.tf
+++ b/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive2.tf
@@ -1,0 +1,18 @@
+resource "google_dns_managed_zone" "dns_zone" {
+  name        = var.zone_id
+  dns_name    = var.name
+  description = "managed by Runtime DNA"
+  visibility  = length(var.vpc_id) == 0 ? "public" : "private"
+
+  dynamic "private_visibility_config" {
+    for_each = length(var.vpc_id) > 0 ? [1] : []
+    content {
+      dynamic "networks" {
+        for_each = toset(var.vpc_id)
+        content {
+          network_url = networks.value
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive_expected_result.json
@@ -2,6 +2,13 @@
 	{
 		"queryName": "Cloud DNS Without DNSSEC",
 		"severity": "MEDIUM",
-		"line": 10
+		"line": 10,
+    "fileName": "positive.tf"
+	},
+  {
+		"queryName": "Cloud DNS Without DNSSEC",
+		"severity": "MEDIUM",
+		"line": 10,
+    "fileName": "positive1.tf"
 	}
 ]

--- a/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/cloud_dns_without_dnssec/test/positive_expected_result.json
@@ -10,5 +10,11 @@
 		"severity": "MEDIUM",
 		"line": 10,
     "fileName": "positive1.tf"
+	},
+  {
+		"queryName": "Cloud DNS Without DNSSEC",
+		"severity": "MEDIUM",
+		"line": 1,
+    "fileName": "positive2.tf"
 	}
 ]


### PR DESCRIPTION
One of the 7 rules that Checkov flags but we don't is this one.
Basically the logic we had and the logic Checkov looks for is quite different:

Checkov:
Aspect | Behavior
-- | --
Resource | google_dns_managed_zone
Key to check | dnssec_config[0].state
Expected values | "on" or "transfer"
Missing key | Implicitly fails unless exempted
Exception condition | If visibility = private, return UNKNOWN (don’t check DNSSEC)
</body></html>

IaC Scanning:
Aspect | Behavior
-- | --
Resource | google_dns_managed_zone
Key to check | resource.dnssec_config.state, or array-style lookup
Expected values | "on" only
Missing key | Requires explicit == null or not valid_key(...)
Exception condition | None — visibility not checked
</body></html>

This PR modifies the logic in our rego check to more closely mimic the logic of the checkov rule