### PR TITLE
[K9VULN-5258] Change Shielded VM logic to properly flag

### DIFF
--- a/assets/queries/terraform/gcp/shielded_vm_disabled/query.rego
+++ b/assets/queries/terraform/gcp/shielded_vm_disabled/query.rego
@@ -3,53 +3,83 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
+# Flag when 'enable_vtpm' or 'enable_integrity_monitoring' is false (object form)
 CxPolicy[result] {
-	document := input.document[i]
+  document := input.document[_]
+  resource := document.resource.google_compute_instance[name]
 
-	compute_instance := document.data.google_compute_instance[appserver]
+  not skip_instance_check(resource)
 
-	not common_lib.valid_key(compute_instance, "shielded_instance_config")
+  fields := ["enable_vtpm", "enable_integrity_monitoring"]
+  field := fields[_]
 
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "google_compute_instance",
-		"resourceName": tf_lib.get_resource_name(compute_instance, appserver),
-		"searchKey": sprintf("google_compute_instance[%s]", [appserver]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "Attribute 'shielded_instance_config' should be defined and not null",
-		"keyActualValue": "Attribute 'shielded_instance_config' is undefined or null",
-	}
+  is_object(resource.shielded_instance_config)
+  resource.shielded_instance_config[field] == false
+
+  result := {
+    "documentId": document.id,
+    "resourceType": "google_compute_instance",
+    "resourceName": tf_lib.get_resource_name(resource, name),
+    "searchKey": sprintf("google_compute_instance[%s].shielded_instance_config.%s", [name, field]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": sprintf("Attribute 'shielded_instance_config.%s' should be true", [field]),
+    "keyActualValue": sprintf("Attribute 'shielded_instance_config.%s' is false", [field]),
+    "searchLine": common_lib.build_search_line(["resource", "google_compute_instance", name, "shielded_instance_config", field], [])
+  }
+}
+
+# Flag when 'enable_vtpm' or 'enable_integrity_monitoring' is false (array form)
+CxPolicy[result] {
+  document := input.document[_]
+  resource := document.resource.google_compute_instance[name]
+
+  not skip_instance_check(resource)
+
+  fields := ["enable_vtpm", "enable_integrity_monitoring"]
+  field := fields[_]
+
+  is_array(resource.shielded_instance_config)
+  index := array_index(resource.shielded_instance_config, field)
+
+  result := {
+    "documentId": document.id,
+    "resourceType": "google_compute_instance",
+    "resourceName": tf_lib.get_resource_name(resource, name),
+    "searchKey": sprintf("google_compute_instance[%s].shielded_instance_config[%d].%s", [name, index, field]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": sprintf("Attribute 'shielded_instance_config.%s' should be true", [field]),
+    "keyActualValue": sprintf("Attribute 'shielded_instance_config.%s' is false", [field]),
+    "searchLine": common_lib.build_search_line(["resource", "google_compute_instance", name, "shielded_instance_config", index, field], [])
+  }
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	compute_instance := document.data.google_compute_instance[appserver]
-	fields := ["enable_secure_boot", "enable_vtpm", "enable_integrity_monitoring"]
-	fieldTypes := fields[_]
-	not common_lib.valid_key(compute_instance.shielded_instance_config, fieldTypes)
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "google_compute_instance",
-		"resourceName": tf_lib.get_resource_name(compute_instance, appserver),
-		"searchKey": sprintf("google_compute_instance[%s].shielded_instance_config", [appserver]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Attribute 'shielded_instance_config.%s' should be defined", [fieldTypes]),
-		"keyActualValue": sprintf("Attribute 'shielded_instance_config.%s' is undefined", [fieldTypes]),
-	}
+  document := input.document[_]
+  resource := document.resource.google_compute_instance[name]
+
+  not skip_instance_check(resource)
+  not common_lib.valid_key(resource, "shielded_instance_config")
+
+  result := {
+    "documentId": document.id,
+    "resourceType": "google_compute_instance",
+    "resourceName": tf_lib.get_resource_name(resource, name),
+    "searchKey": sprintf("google_compute_instance[%s].shielded_instance_config", [name]),
+    "issueType": "MissingAttribute",
+    "keyExpectedValue": "shielded_instance_config block should be present",
+    "keyActualValue": "shielded_instance_config block is missing",
+    "searchLine": common_lib.build_search_line(["resource", "google_compute_instance", name], [])
+  }
 }
 
-CxPolicy[result] {
-	document := input.document[i]
-	compute_instance := document.data.google_compute_instance[appserver]
-	fields := ["enable_secure_boot", "enable_vtpm", "enable_integrity_monitoring"]
-	compute_instance.shielded_instance_config[fields[j]] == false
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "google_compute_instance",
-		"resourceName": tf_lib.get_resource_name(compute_instance, appserver),
-		"searchKey": sprintf("google_compute_instance[%s].shielded_instance_config.%s", [appserver, fields[j]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Attribute 'shielded_instance_config.%s' should be true", [fields[j]]),
-		"keyActualValue": sprintf("Attribute 'shielded_instance_config.%s' is false", [fields[j]]),
-	}
+# Helper to get index in array where field is false
+array_index(arr, field) = idx {
+  some idx
+  arr[idx][field] == false
+}
+
+# Skip instances created from templates without a local override
+skip_instance_check(resource) {
+  resource.source_instance_template
+  not resource.shielded_instance_config
 }

--- a/assets/queries/terraform/gcp/shielded_vm_disabled/test/positive1.tf
+++ b/assets/queries/terraform/gcp/shielded_vm_disabled/test/positive1.tf
@@ -1,0 +1,53 @@
+resource "google_compute_instance" "jumpbox" {
+  name         = "${var.name}-jumpbox"
+  machine_type = var.instance_type
+  zone         = element(var.zones, 0)
+
+  boot_disk {
+    initialize_params {
+      image = "${var.images_source}/${var.image_family}"
+      size  = var.boot_disk_size
+      type  = var.boot_disk_type
+    }
+  }
+
+  network_interface {
+    subnetwork = var.subnet
+  }
+
+  metadata = {}
+
+  service_account {
+    scopes = []
+  }
+
+  tags = ["public", "jumpbox"]
+}
+
+resource "google_compute_firewall" "jumpbox" {
+  name    = "${var.name}-ssh-to-jumpbox"
+  network = var.network
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_tags = ["appgate-gateway"]
+
+  target_tags = ["jumpbox"]
+}
+
+resource "google_compute_firewall" "jumpbox_service" {
+  name    = "${var.name}-jumpbox-service"
+  network = var.network
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "443"]
+  }
+
+  source_tags = ["jumpbox"]
+
+  target_tags = ["jumpbox-service"]
+}


### PR DESCRIPTION
This rule wasn't properly handling objects and arrays as well as was using different logic than the Checkov implementation.