### PR TITLE
[K9VULN-5367] Update fingerprint hash to be location and rule based only

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -578,13 +578,7 @@ compute_raw_resource_name(resource, resourceDefinitionName) = name {
 }
 
 get_resource_name(resource, resourceDefinitionName) = final_name {
-    name := compute_raw_resource_name(resource, resourceDefinitionName)
-    contains(name, ".")
     final_name := resourceDefinitionName
-} else = final_name {
-    name := compute_raw_resource_name(resource, resourceDefinitionName)
-    not contains(name, ".")
-    final_name := name
 }
 
 get_specific_resource_name(resource, resourceType, resourceDefinitionName) = name {

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -784,5 +784,5 @@ func (sr *sarifReport) ResolveFilepaths(basePath string) error {
 }
 
 func GetDatadogFingerprintHash(sciInfo model.SCIInfo, filePath string, startLine int, ruleId string) string {
-	return StringToHash(fmt.Sprintf("%s|%s|%s|%s|%d|%s", sciInfo.RunType, sciInfo.RepositoryCommitInfo.CommitSHA, sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, startLine, ruleId))
+	return StringToHash(fmt.Sprintf("%s|%s|%d|%s", sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, startLine, ruleId))
 }

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -700,7 +700,7 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult, sciInfo model.S
 					"tags": resultTags,
 				},
 				PartialFingerprints: SarifPartialFingerprints{
-					DatadogFingerprint: GetDatadogFingerprintHash(sciInfo, absoluteFilePath, line, issue.QueryID),
+					DatadogFingerprint: GetDatadogFingerprintHash(sciInfo, absoluteFilePath, resourceType, resourceName, issue.QueryID),
 				},
 			}
 			if includeRemediations {
@@ -783,6 +783,6 @@ func (sr *sarifReport) ResolveFilepaths(basePath string) error {
 	return nil
 }
 
-func GetDatadogFingerprintHash(sciInfo model.SCIInfo, filePath string, startLine int, ruleId string) string {
-	return StringToHash(fmt.Sprintf("%s|%s|%d|%s", sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, startLine, ruleId))
+func GetDatadogFingerprintHash(sciInfo model.SCIInfo, filePath, resourceType, resourceName, ruleId string) string {
+	return StringToHash(fmt.Sprintf("%s|%s|%s|%s|%s", sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, resourceType, resourceName, ruleId))
 }

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/Checkmarx/kics/internal/constants"
 	"github.com/Checkmarx/kics/pkg/model"
@@ -785,9 +784,5 @@ func (sr *sarifReport) ResolveFilepaths(basePath string) error {
 }
 
 func GetDatadogFingerprintHash(sciInfo model.SCIInfo, filePath string, startLine int, ruleId string) string {
-	runTypeRelatedInfo := sciInfo.RepositoryCommitInfo.CommitSHA
-	if sciInfo.RunType == "full_scan" {
-		runTypeRelatedInfo = time.Now().Format("2006/01/02")
-	}
-	return StringToHash(fmt.Sprintf("%s|%s|%s|%s|%d|%s", sciInfo.RunType, runTypeRelatedInfo, sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, startLine, ruleId))
+	return StringToHash(fmt.Sprintf("%s|%s|%s|%s|%d|%s", sciInfo.RunType, sciInfo.RepositoryCommitInfo.CommitSHA, sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, startLine, ruleId))
 }


### PR DESCRIPTION
Per [#incident-38662](https://dd.enterprise.slack.com/archives/C08TB0R9NQ5) we need to make the fingerprint hash NOT be run type or date specific.
The fingerprint hash will now just be an encoded string representing the repo, filepath, violation start line and rule id.