### PR TITLE
[K9VULN-5517] Address false positives in sensitive ports rule

### DIFF
--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/query.rego
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/query.rego
@@ -4,54 +4,44 @@ import data.generic.terraform as tf_lib
 import data.generic.common as commonLib
 
 CxPolicy[result] {
-	resource := input.document[i].resource.aws_security_group[name]
+  resource := input.document[i].resource.aws_security_group[name]
+  ingress := resource.ingress[j]
+  protocol := tf_lib.getProtocolList(ingress.protocol)[_]
 
-	portContent := commonLib.tcpPortsMap[port]
-	portNumber = port
-	portName = portContent
-	protocol := tf_lib.getProtocolList(resource.ingress.protocol)[_]
+  endswith(ingress.cidr_blocks[_], "/0")
+  port := getMatchedPort(ingress)[_]
 
-	endswith(resource.ingress.cidr_blocks[_], "/0")
-	tf_lib.containsPort(resource.ingress, portNumber)
-	isTCPorUDP(protocol)
+  sensitive_tcp_port(port, protocol, portName)
 
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_security_group",
-		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_security_group[%s].ingress", [name]),
-		"searchValue": sprintf("%s,%d", [protocol, portNumber]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s (%s:%d) should not be allowed", [portName, protocol, portNumber]),
-		"keyActualValue": sprintf("%s (%s:%d) is allowed", [portName, protocol, portNumber]),
-	}
+  result := {
+    "documentId": input.document[i].id,
+    "resourceType": "aws_security_group",
+    "resourceName": tf_lib.get_resource_name(resource, name),
+    "searchKey": sprintf("aws_security_group[%s].ingress", [name]),
+    "searchValue": sprintf("%s,%d", [protocol, port]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": sprintf("%s (%s:%d) should not be allowed", [portName, protocol, port]),
+    "keyActualValue": sprintf("%s (%s:%d) is allowed", [portName, protocol, port]),
+  }
 }
 
-CxPolicy[result] {
-	resource := input.document[i].resource.aws_security_group[name]
-
-	portContent := commonLib.tcpPortsMap[port]
-	portNumber = port
-	portName = portContent
-    ingress := resource.ingress[j]
-	protocol := tf_lib.getProtocolList(ingress.protocol)[_]
-
-	endswith(ingress.cidr_blocks[_], "/0")
-	tf_lib.containsPort(ingress, portNumber)
-	isTCPorUDP(protocol)
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_security_group",
-		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_security_group[%s].ingress", [name]),
-		"searchValue": sprintf("%s,%d", [protocol, portNumber]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s (%s:%d) should not be allowed", [portName, protocol, portNumber]),
-		"keyActualValue": sprintf("%s (%s:%d) is allowed", [portName, protocol, portNumber]),
-	}
+isTCP(protocol) {
+  lower(protocol) == "tcp"
 }
 
-isTCPorUDP("TCP") = true
+# Only match if the protocol is TCP and the port is in tcpPortsMap
+sensitive_tcp_port(port, protocol) = portName {
+  isTCP(protocol)
+  portName := commonLib.tcpPortsMap[port]
+}
 
-isTCPorUDP("UDP") = true
+getMatchedPort(ingress) = ports {
+  from := ingress.from_port
+  to := ingress.to_port
+
+  ports := [p |
+    i := [j | j := 0; j <= to - from][_]
+    p := from + i
+    p <= to
+  ]
+}

--- a/assets/queries/terraform/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/terraform/aws/unknown_port_exposed_to_internet/query.rego
@@ -4,41 +4,41 @@ import data.generic.terraform as tf_lib
 import data.generic.common as commonLib
 
 CxPolicy[result] {
-	resource := input.document[i].resource.aws_security_group[name]
-	ingress := getIngressList(resource.ingress)
-	cidr := ingress[j].cidr_blocks
+  resource := input.document[i].resource.aws_security_group[name]
+  ingress := getIngressList(resource.ingress)[j]
 
-	unknownPort(ingress[j].from_port, ingress[j].to_port)
-	isEntireNetwork(cidr)
+  cidr_block := ingress.cidr_blocks[_]
+  isEntireNetwork(cidr_block)
 
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_security_group",
-		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_security_group[%s].ingress.cidr_blocks", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_security_group[%s].ingress ports are known", [name]),
-		"keyActualValue": sprintf("aws_security_group[%s].ingress ports are unknown and exposed to the entire Internet", [name]),
-		"searchLine": commonLib.build_search_line(["resource", "aws_security_group", name, "ingress", j, "cidr_blocks"], []),
-	}
+  unknownPort(ingress.from_port, ingress.to_port)
+
+  result := {
+    "documentId": input.document[i].id,
+    "resourceType": "aws_security_group",
+    "resourceName": tf_lib.get_resource_name(resource, name),
+    "searchKey": sprintf("aws_security_group[%s].ingress.cidr_blocks", [name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": sprintf("aws_security_group[%s].ingress ports are known", [name]),
+    "keyActualValue": sprintf("aws_security_group[%s].ingress ports are unknown and exposed to the entire Internet", [name]),
+    "searchLine": commonLib.build_search_line(["resource", "aws_security_group", name, "ingress", j, "cidr_blocks"], []),
+  }
 }
 
 getIngressList(ingress) = list {
-	is_array(ingress)
-	list := ingress
+  type_name(ingress) == "array"
+  list := ingress
 } else = list {
-	is_object(ingress)
-	list := [ingress]
-} else = null {
-	true
+  type_name(ingress) == "object"
+  list := [ingress]
 }
 
-unknownPort(from_port,to_port) {
-	port := numbers.range(from_port, to_port)[i]
-	not commonLib.valid_key(commonLib.tcpPortsMap, port)
+unknownPort(from_port, to_port) {
+  from_port <= to_port
+  offset := [i | i := 0; i <= to_port - from_port][_]
+  port := from_port + offset
+  not commonLib.valid_key(commonLib.tcpPortsMap, port)
 }
 
-isEntireNetwork(cidr) = allow {
-	count({x | cidr[x]; cidr[x] == "0.0.0.0/0"}) != 0
-	allow = true
+isEntireNetwork(cidr) {
+  cidr == "0.0.0.0/0"
 }


### PR DESCRIPTION
This rule was being overly aggressive and not differentiating between TCP and UDP cases properly. Additionally we weren't handling the unknown ports case properly either.