### PR TITLE
K9VULN-5262 fix Ensure that RDP access is restricted from the internet

### DIFF
--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/query.rego
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/query.rego
@@ -6,10 +6,10 @@ CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_network_security_rule[var0]
 	upper(resource.access) == "ALLOW"
 	upper(resource.direction) == "INBOUND"
-	
+
 	isRelevantProtocol(resource.protocol)
 	isRelevantPort(resource.destination_port_range)
-	isRelevantAddressPrefix(resource.source_address_prefix)
+    hasRelevantSourceAddress(resource)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -41,6 +41,20 @@ else = allow {
 	allow = true
 }
 
+hasRelevantSourceAddress(resource) {
+	isRelevantAddressPrefix(resource.source_address_prefix)
+}
+
+hasRelevantSourceAddress(resource) {
+	isRelevantAddressPrefixes(resource.source_address_prefixes)
+}
+
+isRelevantAddressPrefixes(prefixes) = allow {
+    some prefix
+    isRelevantAddressPrefix(prefixes[prefix])
+    allow = true
+}
+
 isRelevantAddressPrefix(prefix) = allow {
 	prefix == "*"
 	allow = true
@@ -57,11 +71,11 @@ else = allow {
 }
 
 else = allow {
-	prefix == "internet"
+	lower(prefix) == "internet"
 	allow = true
 }
 
 else = allow {
-	prefix == "any"
+	lower(prefix) == "any"
 	allow = true
 }

--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/positive.tf
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/positive.tf
@@ -137,3 +137,31 @@ resource "azurerm_network_security_rule" "positive10" {
      resource_group_name         = azurerm_resource_group.example.name
      network_security_group_name = azurerm_network_security_group.example.name
 }
+
+resource "azurerm_network_security_rule" "positive11" {
+  name                        = "example"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "111-211, 2000-4430, 1-2 , 3"
+  source_address_prefix       = "Internet"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.example.name
+  network_security_group_name = azurerm_network_security_group.example.name
+}
+
+resource "azurerm_network_security_rule" "positive12" {
+  name                        = "example"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "3389"
+  source_address_prefixes     = ["something", "Internet", "somethingElse"]
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.example.name
+  network_security_group_name = azurerm_network_security_group.example.name
+}


### PR DESCRIPTION
check source for "any"/"internet" with case insensitivity. 
Check destination_address_prefixes as well as destination_address_prefix
