### PR TITLE
AWS ElasticSearch OpenSearch finegrain access not flagging on missing 

### DIFF
--- a/assets/queries/terraform/aws/elasticsearch_no_finegrain_access_control/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_no_finegrain_access_control/query.rego
@@ -3,38 +3,63 @@ package Cx
 import data.generic.terraform as tf_lib
 import data.generic.common as common_lib
 
-CxPolicy[result] {
-    resource := input.document[i].resource.aws_opensearch_domain[name]
+domains := {
+  "aws_opensearch_domain",
+  "aws_elasticsearch_domain"
+}
 
-    resource.advanced_security_options.internal_user_database_enabled != true
-    resource.advanced_security_options.enabled != true
+CxPolicy[result] {
+    resource_type := domains[_]
+    resource := input.document[i].resource[resource_type][name]
+
+    common_lib.valid_key(resource, "advanced_security_options")
 
     result := {
         "documentId": input.document[i].id,
-        "resourceType": "aws_opensearch_domain",
+        "resourceType": resource_type,
         "resourceName": tf_lib.get_resource_name(resource, name),
-        "searchKey": sprintf("aws_opensearch_domain[{{%s}}].advanced_security_options", [name]),
-        "searchLine": common_lib.build_search_line(["resource", "aws_opensearch_domain", name, "advanced_security_options"], []),
-        "issueType": "IncorrectValue",
-        "keyExpectedValue": "advanced_security_options.internal_user_database_enabled and advanced_security_options.enabled should be true",
-        "keyActualValue": "advanced_security_options.internal_user_database_enabled or advanced_security_options.enabled is false"
+        "searchKey": sprintf("%s[{{%s}}].advanced_security_options", [resource_type, name]),
+        "searchLine": common_lib.build_search_line(["resource", resource_type, name, "advanced_security_options"], []),
+        "issueType": "MissingAttribute",
+        "keyExpectedValue": "advanced_security_options block should be present with enabled = true and internal_user_database_enabled = true",
+        "keyActualValue": "advanced_security_options block is missing"
     }
 }
 
 CxPolicy[result] {
-    resource := input.document[i].resource.aws_elasticsearch_domain[name]
+    resource_type := domains[_]
+    resource := input.document[i].resource[resource_type][name]
 
-    resource.advanced_security_options.internal_user_database_enabled != true
-    resource.advanced_security_options.enabled != true
+    common_lib.valid_key(resource.advanced_security_options, "enabled")
+    not resource.advanced_security_options.enabled
 
     result := {
         "documentId": input.document[i].id,
-        "resourceType": "aws_elasticsearch_domain",
+        "resourceType": resource_type,
         "resourceName": tf_lib.get_resource_name(resource, name),
-        "searchKey": sprintf("aws_elasticsearch_domain[{{%s}}].advanced_security_options", [name]),
-        "searchLine": common_lib.build_search_line(["resource", "aws_elasticsearch_domain", name, "advanced_security_options"], []),
+        "searchKey": sprintf("%s[{{%s}}].advanced_security_options", [resource_type, name]),
+        "searchLine": common_lib.build_search_line(["resource", resource_type, name, "advanced_security_options"], []),
         "issueType": "IncorrectValue",
-        "keyExpectedValue": "advanced_security_options.internal_user_database_enabled and advanced_security_options.enabled should be true",
-        "keyActualValue": "advanced_security_options.internal_user_database_enabled or advanced_security_options.enabled is false"
+        "keyExpectedValue": "advanced_security_options.enabled should be true",
+        "keyActualValue": "advanced_security_options.enabled is false"
+    }
+}
+
+CxPolicy[result] {
+    resource_type := domains[_]
+    resource := input.document[i].resource[resource_type][name]
+
+    common_lib.valid_key(resource.advanced_security_options, "internal_user_database_enabled")
+    not resource.advanced_security_options.internal_user_database_enabled
+
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": resource_type,
+        "resourceName": tf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("%s[{{%s}}].advanced_security_options.internal_user_database_enabled", [resource_type, name]),
+        "searchLine": common_lib.build_search_line(["resource", resource_type, name, "advanced_security_options", "internal_user_database_enabled"], []),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "advanced_security_options.internal_user_database_enabled should be true",
+        "keyActualValue": "advanced_security_options.internal_user_database_enabled is false"
     }
 }

--- a/assets/queries/terraform/aws/elasticsearch_no_finegrain_access_control/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_no_finegrain_access_control/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
     resource_type := domains[_]
     resource := input.document[i].resource[resource_type][name]
 
-    common_lib.valid_key(resource, "advanced_security_options")
+    not common_lib.valid_key(resource, "advanced_security_options")
 
     result := {
         "documentId": input.document[i].id,

--- a/assets/queries/terraform/aws/elasticsearch_no_finegrain_access_control/test/positive.tf
+++ b/assets/queries/terraform/aws/elasticsearch_no_finegrain_access_control/test/positive.tf
@@ -33,3 +33,9 @@ resource "aws_elasticsearch_domain" "bad_example4" {
     internal_user_database_enabled = true
   }
 }
+
+resource "aws_elasticsearch_domain" "bad_example5" {
+  domain_name = "example"
+
+                                              # ❌ No advanced_security_options block
+}


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- KICS and Checkov are showing some discrepancies right now in the way they work: KICS is not creating any alert when the advanced_security_options block is missing. This PR's aim is to fix this.

**Proposed Changes**
- Changed the Rego logic to add the missing advanced_security_options block as a reason to flag
- Added a test case to the positive.tf file to ensure the previously explained logic works fine

I submit this contribution under the Apache-2.0 license.