### PR TITLE
[K9VULN-6090] Support inclusion lists in config file

### DIFF
--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -89,7 +89,7 @@ func GetDefaultParameters(rootPath string) *Parameters {
 		ExcludeSeverities:           configParams.ExcludeSeverities,
 		ExcludePaths:                configParams.ExcludePaths,
 		ExperimentalQueries:         false,
-		IncludeQueries:              []string{},
+		IncludeQueries:              configParams.IncludeQueries,
 		InputData:                   "",
 		OutputName:                  "kics-result.sarif",
 		PayloadPath:                 "",

--- a/pkg/scan/pre_scan.go
+++ b/pkg/scan/pre_scan.go
@@ -16,6 +16,7 @@ type ConfigParameters struct {
 	ExcludeQueries    []string
 	ExcludeResults    []string
 	ExcludeSeverities []string
+	IncludeQueries    []string
 }
 
 func setupConfigFile(rootPath string) (bool, error) {
@@ -80,6 +81,9 @@ func initializeConfig(rootPath string) (ConfigParameters, error) {
 	}
 	if v.Get("exclude-severities") != nil {
 		configParams.ExcludeSeverities = v.GetStringSlice("exclude-severities")
+	}
+	if v.Get("include-queries") != nil {
+		configParams.IncludeQueries = v.GetStringSlice("include-queries")
 	}
 
 	return configParams, nil


### PR DESCRIPTION
In prep for enabling IaC scanning for cloud-inventory Checkov displacement work we need to support inclusion lists and not just exclusions. Luckily KICS has support for this already in some form so we just need to tweak to fit.