### PR TITLE
K9VULN-6111 Remove fatal log and have kics return error

### DIFF
--- a/kics.go
+++ b/kics.go
@@ -15,14 +15,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string) {
+func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIInfo) (scan.ScanMetadata, string, error) {
 	params := scan.GetDefaultParameters(outputPath)
 	params.Path = inputPaths
 	params.OutputPath = outputPath
 	params.SCIInfo = sciInfo
 	metadata, err := console.ExecuteScan(params)
 	if err != nil {
-		log.Fatal().Int64(
+		log.Error().Int64(
 			"org", sciInfo.OrgId,
 		).Str(
 			"branch", sciInfo.RepositoryCommitInfo.Branch,
@@ -31,7 +31,7 @@ func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIIn
 		).Str(
 			"repository", sciInfo.RepositoryCommitInfo.RepositoryUrl,
 		).Msgf("failed to execute scan: %v", err)
-		return scan.ScanMetadata{}, ""
+		return scan.ScanMetadata{}, "", err
 	}
 
 	log.Info().Int64(
@@ -47,6 +47,5 @@ func ExecuteKICSScan(inputPaths []string, outputPath string, sciInfo model.SCIIn
 	)
 
 	resultsFile := filepath.Join(outputPath, params.OutputName)
-	return metadata, resultsFile
-
+	return metadata, resultsFile, nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,7 +46,7 @@ func Test_E2EExclusions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metadata, _ := kics.ExecuteKICSScan(
+			metadata, _, err := kics.ExecuteKICSScan(
 				[]string{tt.testFile},
 				"",
 				model.SCIInfo{
@@ -61,6 +61,7 @@ func Test_E2EExclusions(t *testing.T) {
 					},
 				},
 			)
+			require.NoError(t, err)
 			require.Equal(t, tt.expectedOutput.Violations, metadata.Stats.Violations)
 			require.Equal(t, tt.expectedOutput.Files, metadata.Stats.Files)
 			require.Equal(t, tt.expectedOutput.Rules, metadata.Stats.Rules)


### PR DESCRIPTION

**Reason for Proposed Changes**
- Stop iac-scanning crashes due to kics errors

**Proposed Changes**
- Remove fatal log
- return error instead

I submit this contribution under the Apache-2.0 license.