### PR TITLE
[K9VULN-6230] Changed URL to our docs

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -97,8 +97,8 @@ const (
 	// Fullname - KICS fullname
 	Fullname = "Keeping Infrastructure as Code Secure"
 
-	// URL - KICS url
-	URL = "https://www.kics.io/"
+	// URL - DD Docs url
+	URL = "https://docs.datadoghq.com/security/code_security/iac_security/"
 
 	// DefaultLogFile - logfile name
 	DefaultLogFile = "info.log"


### PR DESCRIPTION
In the constants.go, the url previously pointing the kics website is now pointing our docs

Refs: K9VULN-6230

Closes #

**Reason for Proposed Changes**
- The KICS URL needs to be removed from the rules as it is no longer necessary. Now that we have better documentation, the URL can be swapped out.

**Proposed Changes**
- Changed the constant
-
-

I submit this contribution under the Apache-2.0 license.