### PR TITLE
[incident-41687] fix typo in resource type for rule `alb_not_dropping_invalid_headers`

### DIFF
--- a/assets/queries/terraform/aws/alb_not_dropping_invalid_headers/query.rego
+++ b/assets/queries/terraform/aws/alb_not_dropping_invalid_headers/query.rego
@@ -87,7 +87,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": module,
+		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
 		"searchKey": sprintf("module[%s]", [name]),
 		"issueType": "MissingAttribute",


### PR DESCRIPTION
The resourceType was incorrectly set due to a typo.

Refs: incident-41687

I submit this contribution under the Apache-2.0 license.