### PR TITLE
[K9VULN-7505] CICD PoC

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -1,0 +1,32 @@
+name: check-go-coverage
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration-tests:
+    name: integration-tests
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #V4.2.2
+          
+        - name: Set up Go
+          uses: actions/setup-go@v5
+          with:
+            go-version: '1.22'
+
+        - name: Generate Test Report
+          run: |
+            mkdir -p ./ctrf
+            go test -json ./... \
+            | go run github.com/ctrf-io/go-ctrf-json-reporter/cmd/go-ctrf-json-reporter@latest \
+                -output ./ctrf/ctrf-report.json 
+
+        - name: Publish Test Report
+          uses: ctrf-io/github-test-reporter@v1
+          with:
+            report-path: './ctrf/*.json'
+            github-report: true
+          if: always()

--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -1,4 +1,6 @@
 name: check-go-coverage
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -29,50 +29,39 @@ func GetEmbeddedLibraryData(platform string) (string, error) {
 	return string(content), err
 }
 
-//go:embed queries/cicd
-var cicdEmbeddedQueries embed.FS
-
-//go:embed queries/terraform
-var terraformEmbeddedQueries embed.FS
-
-var embeddedQueries []embed.FS = []embed.FS{cicdEmbeddedQueries, terraformEmbeddedQueries}
+//go:embed queries/cicd queries/terraform
+var embeddedQueries embed.FS
 
 func GetEmbeddedQueryDirs(ctx context.Context) ([]string, error) {
 	logger := logger.FromContext(ctx)
 	var out []string
-	for _, embeddedQueriesList := range embeddedQueries {
-		err := fs.WalkDir(embeddedQueriesList, ".", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				logger.Info().Msgf("Failed to walk directory: %s", path)
-				return err
-			}
-			baseDir := filepath.Base(path)
-			if baseDir == "test" {
-				return nil
-			}
-			if d.IsDir() {
-				out = append(out, path)
-			}
-			return nil
-		})
+	err := fs.WalkDir(embeddedQueries, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			logger.Error().Msgf("Failed to walk embedded directory for queries: %v", err)
-			return nil, err
+			logger.Info().Msgf("Failed to walk directory: %s", path)
+			return err
 		}
+		baseDir := filepath.Base(path)
+		if baseDir == "test" {
+			return nil
+		}
+		if d.IsDir() {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		logger.Error().Msgf("Failed to walk embedded directory for queries: %v", err)
+		return nil, err
 	}
 	return out, nil
 }
 
 func GetEmbeddedQueryFile(ctx context.Context, path string) (string, error) {
 	logger := logger.FromContext(ctx)
-	var content []byte
-	var err error
-	for _, embeddedQueriesList := range embeddedQueries {
-		content, err = embeddedQueriesList.ReadFile(path)
-		if err == nil {
-			return string(content), nil
-		}
+	content, err := embeddedQueries.ReadFile(path)
+	if err != nil {
+		logger.Debug().Msgf("Failed to read file for path %s: %v", path, err)
+		return "", err
 	}
-	logger.Debug().Msgf("Failed to read file for path %s: %v", path, err)
-	return "", err
+	return string(content), nil
 }

--- a/assets/queries/cicd/github/run_block_injection/query.rego
+++ b/assets/queries/cicd/github/run_block_injection/query.rego
@@ -27,7 +27,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -50,7 +52,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -74,7 +78,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -97,7 +103,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -121,7 +129,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -148,7 +158,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -171,7 +183,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 

--- a/assets/queries/cicd/github/run_block_injection/test/positive1.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive1.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Crawl pages and generate Markdown files
         uses: freeCodeCamp-China/article-webpage-to-markdown-action@v0.1.8
         with:
-          newsLink: '${{ github.event.issue.Body }}'
+          newsLink: '${{ github.event.issue.body }}'
           markDownFilePath: './chinese/articles/'
           githubToken: ${{ github.token }}
       - name: Git Auto Commit

--- a/assets/queries/cicd/github/script_block_injection/query.rego
+++ b/assets/queries/cicd/github/script_block_injection/query.rego
@@ -32,7 +32,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -60,7 +62,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -89,7 +93,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with","script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -117,7 +123,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -146,7 +154,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -178,7 +188,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -206,7 +218,9 @@ CxPolicy[result] {
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchValue": matched[m],
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("uses={{%s}}", [uses]),
+		"searchKey": sprintf("uses=%s", [uses]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Action pinned to a full length commit SHA.",
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
@@ -15,7 +15,9 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Action pinned to a full length commit SHA.",
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "uses"],[])
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "uses"],[]),
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("uses=%s", [uses]),
+		"searchKey": sprintf("uses={{%s}}", [uses]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Action pinned to a full length commit SHA.",
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",

--- a/assets/queries/cicd/github/unsecured_commands/query.rego
+++ b/assets/queries/cicd/github/unsecured_commands/query.rego
@@ -14,7 +14,9 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
-        "searchLine": common_lib.build_search_line(["env", "ACTIONS_ALLOW_UNSECURE_COMMANDS"],[])
+        "searchLine": common_lib.build_search_line(["env", "ACTIONS_ALLOW_UNSECURE_COMMANDS"],[]),
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -30,7 +32,9 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
-        "searchLine": common_lib.build_search_line(["jobs", j, "env", "ACTIONS_ALLOW_UNSECURE_COMMANDS"],[])
+        "searchLine": common_lib.build_search_line(["jobs", j, "env", "ACTIONS_ALLOW_UNSECURE_COMMANDS"],[]),
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 
@@ -46,7 +50,9 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
-        "searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "env", "ACTIONS_ALLOW_UNSECURE_COMMANDS"],[])
+        "searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "env", "ACTIONS_ALLOW_UNSECURE_COMMANDS"],[]),
+		"resourceType": "github_action",
+		"resourceName": input.document[i].jobs[j].steps[k].name
 	}
 }
 

--- a/assets/queries/cicd/github/unsecured_commands/query.rego
+++ b/assets/queries/cicd/github/unsecured_commands/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("env.actions_allow_unsecure_commands={{%s}}", [env]),
+		"searchKey": sprintf("ACTIONS_ALLOW_UNSECURE_COMMANDS={{%s}}", [env]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
@@ -28,7 +28,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("env.actions_allow_unsecure_commands={{%s}}", [env]),
+		"searchKey": sprintf("ACTIONS_ALLOW_UNSECURE_COMMANDS={{%s}}", [env]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
@@ -46,7 +46,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("env.actions_allow_unsecure_commands={{%s}}", [env]),
+		"searchKey": sprintf("ACTIONS_ALLOW_UNSECURE_COMMANDS={{%s}}", [env]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",

--- a/assets/queries/cicd/github/unsecured_commands/query.rego
+++ b/assets/queries/cicd/github/unsecured_commands/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("ACTIONS_ALLOW_UNSECURE_COMMANDS={{%s}}", [env]),
+		"searchKey": sprintf("env.actions_allow_unsecure_commands={{%s}}", [env]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
@@ -28,7 +28,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("ACTIONS_ALLOW_UNSECURE_COMMANDS={{%s}}", [env]),
+		"searchKey": sprintf("env.actions_allow_unsecure_commands={{%s}}", [env]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",
@@ -46,7 +46,7 @@ CxPolicy[result] {
 	
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("ACTIONS_ALLOW_UNSECURE_COMMANDS={{%s}}", [env]),
+		"searchKey": sprintf("env.actions_allow_unsecure_commands={{%s}}", [env]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is not set as true.",
 		"keyActualValue": "ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable is set as true.",

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -51,6 +51,7 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 		}
 	}
 
+	start, end := model.ResourceLine{}, model.ResourceLine{}
 	for _, key := range splitSanitized {
 		substr1, substr2 := GenerateSubstrings(key, extractedString, lines, detector.CurrentLine)
 
@@ -60,8 +61,7 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 			substr1 = strings.ReplaceAll(substr1, "parameters", "param")
 			substr1 = strings.ReplaceAll(substr1, "variables", "variable")
 		}
-
-		detector, lines = detector.DetectCurrentLine(substr1, substr2, 0, lines)
+		detector, start, end, lines = detector.DetectCurrentLine(substr1, substr2, 0, lines)
 
 		if detector.IsBreak {
 			break
@@ -73,6 +73,10 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 			Line:         detector.CurrentLine + 1,
 			VulnLines:    GetAdjacentVulnLines(detector.CurrentLine, outputLines, lines),
 			ResolvedFile: detector.ResolvedFile,
+			VulnerablilityLocation: model.ResourceLocation{
+				Start: start,
+				End:   end,
+			},
 		}
 	}
 

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -53,7 +53,7 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 
 	start, end := model.ResourceLine{}, model.ResourceLine{}
 	for _, key := range splitSanitized {
-		substr1, substr2 := GenerateSubstrings(key, extractedString, lines, detector.CurrentLine)
+		substr1, substr2 := GenerateSubstrings(ctx, key, extractedString, lines, detector.CurrentLine)
 
 		// BICEP-specific tweaks in order to make bicep files compatible with ARM queries
 		if file.Kind == "BICEP" {

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -61,7 +61,7 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 			substr1 = strings.ReplaceAll(substr1, "parameters", "param")
 			substr1 = strings.ReplaceAll(substr1, "variables", "variable")
 		}
-		detector, start, end, lines = detector.DetectCurrentLine(substr1, substr2, 0, lines)
+		detector, start, end, lines = detector.DetectCurrentLine(substr1, substr2, 0, lines, file.Kind)
 
 		if detector.IsBreak {
 			break

--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -69,7 +69,7 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 
 	// Since we are only looking at keys we can ignore the second value passed through '=' and '[]'
 	for _, key := range strings.Split(sanitizedSubstring, ".") {
-		substr1, _ := detector.GenerateSubstrings(key, extractedString, lines, curLineRes.lineRes)
+		substr1, _ := detector.GenerateSubstrings(ctx, key, extractedString, lines, curLineRes.lineRes)
 		curLineRes = curLineRes.detectCurrentLine(lines, fmt.Sprintf("%s:", substr1), "", true, file.IDInfo, helmID)
 
 		if curLineRes.breakRes {

--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -267,7 +267,7 @@ func (d *DefaultDetectLineResponse) DetectCurrentLine(str1, str2 string, recurse
 
 	if len(distances) == 0 {
 		d.IsBreak = true
-		return d, model.ResourceLine{Line: 0, Col: 0}, model.ResourceLine{Line: 0, Col: 0}, lines
+		return d, model.ResourceLine{Line: d.CurrentLine + 1, Col: 0}, model.ResourceLine{Line: d.CurrentLine + 1, Col: 0}, lines
 	}
 
 	d.CurrentLine = SelectLineWithMinimumDistance(distances, d.CurrentLine)
@@ -312,14 +312,14 @@ func checkLine(str1, str2 string, distances map[int]int, starts map[int]model.Re
 				distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 				distances[startLine] += levenshtein.ComputeDistance(ExtractLineFragment(str2, s, false), s)
 				starts[startLine] = model.ResourceLine{Line: startLine + 1, Col: currentIndent}
-				ends[startLine] = model.ResourceLine{Line: endLine + 1, Col: len(lines[startLine])}
+				ends[startLine] = model.ResourceLine{Line: endLine, Col: len(lines[startLine])}
 			}
 
 		}
 	} else if str1 != "" && strings.Contains(line, str1) {
 		distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 		starts[startLine] = model.ResourceLine{Line: startLine + 1, Col: currentIndent}
-		ends[startLine] = model.ResourceLine{Line: endLine + 1, Col: len(lines[startLine])}
+		ends[startLine] = model.ResourceLine{Line: startLine + 1, Col: len(lines[startLine])}
 	}
 
 	return distances, starts, ends

--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -291,8 +291,8 @@ func checkLine(str1, str2 string, distances map[int]int, starts map[int]model.Re
 		if strings.Contains(restLine, str2) {
 			distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 			distances[startLine] += levenshtein.ComputeDistance(ExtractLineFragment(restLine, str2, false), str2)
-			starts[startLine] = model.ResourceLine{Line: startLine, Col: currentIndent}
-			ends[startLine] = model.ResourceLine{Line: startLine, Col: len(lines[startLine])}
+			starts[startLine] = model.ResourceLine{Line: startLine + 1, Col: currentIndent}
+			ends[startLine] = model.ResourceLine{Line: startLine + 1, Col: len(lines[startLine])}
 		} else if kind == model.KindYAML && yamlMultilineRegex.MatchString(line) {
 			s, nextLine := "", ""
 			for endLine < len(lines) {
@@ -311,13 +311,15 @@ func checkLine(str1, str2 string, distances map[int]int, starts map[int]model.Re
 			) || strings.Contains(nextLine, str2) {
 				distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 				distances[startLine] += levenshtein.ComputeDistance(ExtractLineFragment(str2, s, false), s)
-				starts[startLine] = model.ResourceLine{Line: startLine, Col: currentIndent}
-				ends[startLine] = model.ResourceLine{Line: endLine, Col: len(lines[startLine])}
+				starts[startLine] = model.ResourceLine{Line: startLine + 1, Col: currentIndent}
+				ends[startLine] = model.ResourceLine{Line: endLine + 1, Col: len(lines[startLine])}
 			}
 
 		}
 	} else if str1 != "" && strings.Contains(line, str1) {
 		distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
+		starts[startLine] = model.ResourceLine{Line: startLine + 1, Col: currentIndent}
+		ends[startLine] = model.ResourceLine{Line: endLine + 1, Col: len(lines[startLine])}
 	}
 
 	return distances, starts, ends

--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -19,8 +19,13 @@ import (
 )
 
 var (
-	nameRegex       = regexp.MustCompile(`^([A-Za-z\d-_]+)\[([A-Za-z\d-_{}]+)]$`)
-	nameRegexDocker = regexp.MustCompile(`{{(.*?)}}`)
+	nameRegex          = regexp.MustCompile(`^([A-Za-z\d-_]+)\[([A-Za-z\d-_{}]+)]$`)
+	nameRegexDocker    = regexp.MustCompile(`{{(.*?)}}`)
+	indentRegex        = regexp.MustCompile(`^\s+`)
+	whitespacesRegex   = regexp.MustCompile(`\s+`)
+	yamlMultilineRegex = regexp.MustCompile(
+		`(?m)^[ \t]*-?[ \t]*[^:\n#][^:\n]*:\s*(?:[|>](?:[+-]?\d+|\d+[+-]?|[+-])?|\\)\s*(?:#.*)?$`,
+	)
 )
 
 const (
@@ -279,11 +284,6 @@ func checkLine(str1, str2 string, distances map[int]int, starts map[int]model.Re
 		return distances, starts, ends
 	}
 
-	indentRegex := regexp.MustCompile(`^\s+`)
-	whitespacesRegex := regexp.MustCompile(`\s+`)
-	var yamlMultilineRegex = regexp.MustCompile(
-		`(?m)^[ \t]*-?[ \t]*[^:\n#][^:\n]*:\s*(?:[|>](?:[+-]?\d+|\d+[+-]?|[+-])?|\\)\s*(?:#.*)?$`,
-	)
 	line = indentRegex.ReplaceAllString(line, "")
 	currentIndent := strings.Index(lines[startLine], line)
 	if str1 != "" && str2 != "" && strings.Contains(line, str1) {

--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -7,7 +7,6 @@ package detector
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -40,41 +39,34 @@ type DefaultDetectLineResponse struct {
 
 // GetBracketValues gets values inside "{{ }}" ignoring any "{{" or "}}" inside
 func GetBracketValues(expr string, list [][]string, restOfString string) [][]string {
-	var tempList []string
-	firstOpen := strings.Index(expr, "{{")
-	firstClose := strings.Index(expr, "}}")
-	for firstOpen > firstClose && firstClose != -1 {
-		firstClose = strings.Index(expr[firstOpen:], "}}") + firstOpen
-	}
-	// in case we have '}}}' we need to advance one position to get the close
-	for firstClose+2 < len(expr) && string(expr[firstClose+2]) == `}` && firstClose != -1 {
-		firstClose++
-	}
+	s := expr + restOfString
 
-	switch t := firstClose - firstOpen; t >= 0 {
-	case true:
-		if t == 0 && expr != "" {
-			tempList = append(tempList, fmt.Sprintf("{{%s}}", expr), expr)
-			list = append(list, tempList)
+	depth := 0
+	open := -1  // index of the first '{' in the outermost `{{`
+	start := -1 // inner start = open + 2
+
+	for i := 0; i < len(s)-1; i++ {
+		switch {
+		case s[i] == '{' && s[i+1] == '{':
+			if depth == 0 {
+				open = i
+				start = i + 2
+			}
+			depth++
+			i++ // skip the second '{'
+
+		case s[i] == '}' && s[i+1] == '}':
+			if depth > 0 {
+				depth--
+				if depth == 0 && open >= 0 && start >= 0 {
+					full := s[open : i+2]
+					inner := s[start:i]
+					list = append(list, []string{full, inner})
+					open, start = -1, -1
+				}
+			}
+			i++ // skip the second '}'
 		}
-		if t == 0 && restOfString == "" {
-			return list // if there is no more string to read from return value of list
-		}
-		if t > 0 && firstOpen+2 <= firstClose {
-			list = GetBracketValues(expr[firstOpen+2:firstClose], list, expr[firstClose+2:])
-		} else {
-			list = GetBracketValues(restOfString, list, "") // recursive call to the rest of the string
-		}
-	case false:
-		nextClose := strings.Index(restOfString, "}}")
-		tempNextClose := nextClose + 2
-		if tempNextClose == len(restOfString) {
-			tempNextClose = nextClose
-		}
-		tempList = append(tempList, fmt.Sprintf("{{%s}}%s}}", expr, restOfString[:tempNextClose]),
-			fmt.Sprintf("%s}}%s", expr, restOfString[:tempNextClose]))
-		list = append(list, tempList)
-		list = GetBracketValues(restOfString[nextClose+2:], list, "") // recursive call to the rest of the string
 	}
 
 	return list
@@ -84,103 +76,18 @@ func GetBracketValues(expr string, list [][]string, restOfString string) [][]str
 // '.' is new line
 // '=' is value in the same line
 // '[]' is in the same line
-func GenerateSubstrings(key string, extracted [][]string, lines []string, currentLine int) (string, string) {
+func GenerateSubstrings(ctx context.Context, key string, extracted [][]string, lines []string, currentLine int) (string, string) {
 	var substr1, substr2 string
-
-	// Replace placeholders back to bracketed values
-	for idx, str := range extracted {
-		placeholder := fmt.Sprintf("{{%d}}", idx)
-		key = strings.Replace(key, placeholder, str[0], 1)
-	}
-
-	// Handle [something] or ["key"]
-	if strings.Contains(key, "[") && strings.HasSuffix(key, "]") {
-		start := strings.Index(key, "[")
-		end := strings.LastIndex(key, "]")
-		if start > 0 && end > start {
-			base := key[:start]
-			bracketValue := key[start+1 : end]
-
-			// Strip quotes from map-style keys like ["Name"]
-			bracketValue = strings.Trim(bracketValue, `"'`)
-
-			// Handle placeholders like [{{label}}]
-			if strings.HasPrefix(bracketValue, "{{") && strings.HasSuffix(bracketValue, "}}") {
-				bracketValue = strings.TrimPrefix(bracketValue, "{{")
-				bracketValue = strings.TrimSuffix(bracketValue, "}}")
-			}
-
-			// Handle numeric index
-			if index, err := strconv.Atoi(bracketValue); err == nil {
-				// Use list logic only if this looks like an actual list
-				if looksLikeListAttribute(base, lines) {
-					substr1 = base
-					substr2 = resolveListIndex(base, index, lines)
-					return substr1, substr2
-				}
-				// Otherwise treat it as a block navigation
-				substr1 = base
-				substr2 = "" // no value needed
-				return substr1, substr2
-			}
-
-			// Resource label or map key
-			substr1 = base
-			substr2 = bracketValue
-			return substr1, substr2
-		}
-	}
-
-	// Fallback: key = value
-	parts := strings.SplitN(key, "=", 2)
-	substr1 = strings.TrimSpace(parts[0])
-	if len(parts) > 1 {
-		substr2 = strings.TrimSpace(parts[1])
-	}
-
-	// Final fallback: try to resolve value from lines
-	if substr2 == "" && substr1 != "" {
-		for i := currentLine; i < len(lines); i++ {
-			line := lines[i]
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, substr1+" =") {
-				parts := strings.SplitN(line, "=", 2)
-				if len(parts) == 2 {
-					substr2 = strings.TrimSpace(parts[1])
-				}
-				break
-			}
-		}
+	if parts := nameRegex.FindStringSubmatch(key); len(parts) == namePartsLength {
+		substr1, substr2 = getKeyWithCurlyBrackets(ctx, key, extracted, parts)
+	} else if parts := strings.Split(key, "="); len(parts) == valuePartsLength {
+		substr1, substr2 = getKeyWithCurlyBrackets(ctx, key, extracted, parts)
+	} else {
+		parts := []string{key, ""}
+		substr1, substr2 = getKeyWithCurlyBrackets(ctx, key, extracted, parts)
 	}
 
 	return substr1, substr2
-}
-
-func looksLikeListAttribute(attrName string, lines []string) bool {
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, attrName+" = [") {
-			return true
-		}
-	}
-	return false
-}
-
-func resolveListIndex(attrName string, index int, lines []string) string {
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, attrName+" = [") {
-			start := strings.Index(trimmed, "[")
-			end := strings.Index(trimmed, "]")
-			if start >= 0 && end > start {
-				items := strings.Split(trimmed[start+1:end], ",")
-				if index < len(items) {
-					return strings.Trim(strings.TrimSpace(items[index]), `"`)
-				}
-			}
-		}
-	}
-	return ""
 }
 
 func getKeyWithCurlyBrackets(ctx context.Context, key string, extractedString [][]string, parts []string) (substr1Res, substr2Res string) {
@@ -345,30 +252,31 @@ func removeExtras(result string, start, end int) string {
 
 // DetectCurrentLine uses levenshtein distance to find the most accurate line for the vulnerability
 func (d *DefaultDetectLineResponse) DetectCurrentLine(str1, str2 string, recurseCount int,
-	lines []string) (det *DefaultDetectLineResponse, start model.ResourceLine, end model.ResourceLine, l []string) {
+	lines []string) (*DefaultDetectLineResponse, model.ResourceLine, model.ResourceLine, []string) {
 	distances := make(map[int]int)
+	starts, ends := make(map[int]model.ResourceLine), make(map[int]model.ResourceLine)
 
 	for i := d.CurrentLine; i < len(lines); i++ {
-		distances, start, end = checkLine(str1, str2, distances, lines, i)
+		distances, starts, ends = checkLine(str1, str2, distances, starts, ends, lines, i)
 	}
 
 	if len(distances) == 0 {
 		d.IsBreak = true
-		return d, start, end, lines
+		return d, model.ResourceLine{Line: 0, Col: 0}, model.ResourceLine{Line: 0, Col: 0}, lines
 	}
 
 	d.CurrentLine = SelectLineWithMinimumDistance(distances, d.CurrentLine)
 	d.IsBreak = false
 	d.FoundAtLeastOne = true
 
-	return d, start, end, lines
+	return d, starts[d.CurrentLine], ends[d.CurrentLine], lines
 }
 
-func checkLine(str1, str2 string, distances map[int]int, lines []string, startLine int) (map[int]int, model.ResourceLine, model.ResourceLine) {
+func checkLine(str1, str2 string, distances map[int]int, starts map[int]model.ResourceLine, ends map[int]model.ResourceLine, lines []string, startLine int) (map[int]int, map[int]model.ResourceLine, map[int]model.ResourceLine) {
 	line := strings.TrimSpace(lines[startLine])
-	endLine := startLine
+	endLine := startLine + 1
 	if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
-		return distances, model.ResourceLine{Line: startLine, Col: 0}, model.ResourceLine{Line: 0, Col: 0}
+		return distances, starts, ends
 	}
 
 	regex := regexp.MustCompile(`^\s+`)
@@ -379,12 +287,14 @@ func checkLine(str1, str2 string, distances map[int]int, lines []string, startLi
 		if strings.Contains(restLine, str2) {
 			distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 			distances[startLine] += levenshtein.ComputeDistance(ExtractLineFragment(restLine, str2, false), str2)
+			starts[startLine] = model.ResourceLine{Line: startLine, Col: currentIndent}
+			ends[startLine] = model.ResourceLine{Line: startLine, Col: len(lines[startLine])}
 		} else if strings.Contains(line, "|") {
-			s := ""
+			s, nextLine := "", ""
 			for endLine < len(lines) {
-				nextLine := regex.ReplaceAllString(lines[endLine], "")
+				nextLine = regex.ReplaceAllString(lines[endLine], "")
 				nextIndent := strings.Index(lines[endLine], nextLine)
-				if currentIndent == nextIndent {
+				if currentIndent == nextIndent || strings.Contains(nextLine, str2) {
 					break
 				}
 				s += nextLine
@@ -395,9 +305,11 @@ func checkLine(str1, str2 string, distances map[int]int, lines []string, startLi
 			if strings.Contains(
 				whitespacesRegex.ReplaceAllString(str2, ""),
 				whitespacesRegex.ReplaceAllString(s, ""),
-			) {
+			) || strings.Contains(nextLine, str2) {
 				distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 				distances[startLine] += levenshtein.ComputeDistance(ExtractLineFragment(str2, s, false), s)
+				starts[startLine] = model.ResourceLine{Line: startLine, Col: currentIndent}
+				ends[startLine] = model.ResourceLine{Line: endLine, Col: len(lines[startLine])}
 			}
 
 		}
@@ -405,5 +317,5 @@ func checkLine(str1, str2 string, distances map[int]int, lines []string, startLi
 		distances[startLine] = levenshtein.ComputeDistance(ExtractLineFragment(line, str1, false), str1)
 	}
 
-	return distances, model.ResourceLine{Line: startLine, Col: currentIndent}, model.ResourceLine{Line: endLine, Col: len(lines[startLine])}
+	return distances, starts, ends
 }

--- a/pkg/detector/helper_test.go
+++ b/pkg/detector/helper_test.go
@@ -420,7 +420,7 @@ func TestDetectCurrentLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := tt.fields.defaultDetectLineResponse
 
-			d, _ = d.DetectCurrentLine(tt.args.str1, tt.args.str2, 0, tt.args.lines)
+			d, _, _, _ = d.DetectCurrentLine(tt.args.str1, tt.args.str2, 0, tt.args.lines)
 
 			if d.CurrentLine != tt.want.defaultDetectLineResponse.CurrentLine {
 				t.Errorf("DetectCurrentLine() = %v, want %v", d.CurrentLine, tt.want.defaultDetectLineResponse.CurrentLine)

--- a/pkg/detector/helper_test.go
+++ b/pkg/detector/helper_test.go
@@ -420,7 +420,7 @@ func TestDetectCurrentLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := tt.fields.defaultDetectLineResponse
 
-			d, _, _, _ = d.DetectCurrentLine(tt.args.str1, tt.args.str2, 0, tt.args.lines)
+			d, _, _, _ = d.DetectCurrentLine(tt.args.str1, tt.args.str2, 0, tt.args.lines, "kind")
 
 			if d.CurrentLine != tt.want.defaultDetectLineResponse.CurrentLine {
 				t.Errorf("DetectCurrentLine() = %v, want %v", d.CurrentLine, tt.want.defaultDetectLineResponse.CurrentLine)

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -57,7 +57,7 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 	lines := *file.LinesOriginalData
 
 	for _, part := range keyParts {
-		s1, s2 := detector.GenerateSubstrings(part, extracted, lines, detection.CurrentLine)
+		s1, s2 := GenerateSubstrings(ctx, part, extracted, lines, detection.CurrentLine)
 		detection, _, _, _ = detection.DetectCurrentLine(s1, s2, 0, lines)
 		if detection.IsBreak {
 			break

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -58,7 +58,7 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 
 	for _, part := range keyParts {
 		s1, s2 := GenerateSubstrings(ctx, part, extracted, lines, detection.CurrentLine)
-		detection, _, _, _ = detection.DetectCurrentLine(s1, s2, 0, lines)
+		detection, _, _, _ = detection.DetectCurrentLine(s1, s2, 0, lines, file.Kind)
 		if detection.IsBreak {
 			break
 		}

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -58,7 +58,7 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 
 	for _, part := range keyParts {
 		s1, s2 := detector.GenerateSubstrings(part, extracted, lines, detection.CurrentLine)
-		detection, _ = detection.DetectCurrentLine(s1, s2, 0, lines)
+		detection, _, _, _ = detection.DetectCurrentLine(s1, s2, 0, lines)
 		if detection.IsBreak {
 			break
 		}

--- a/pkg/detector/terraform/terraform_helper.go
+++ b/pkg/detector/terraform/terraform_helper.go
@@ -1,0 +1,107 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func GenerateSubstrings(ctx context.Context, key string, extracted [][]string, lines []string, currentLine int) (string, string) {
+	var substr1, substr2 string
+
+	// Replace placeholders back to bracketed values
+	for idx, str := range extracted {
+		placeholder := fmt.Sprintf("{{%d}}", idx)
+		key = strings.Replace(key, placeholder, str[0], 1)
+	}
+
+	// Handle [something] or ["key"]
+	if strings.Contains(key, "[") && strings.HasSuffix(key, "]") {
+		start := strings.Index(key, "[")
+		end := strings.LastIndex(key, "]")
+		if start > 0 && end > start {
+			base := key[:start]
+			bracketValue := key[start+1 : end]
+
+			// Strip quotes from map-style keys like ["Name"]
+			bracketValue = strings.Trim(bracketValue, `"'`)
+
+			// Handle placeholders like [{{label}}]
+			if strings.HasPrefix(bracketValue, "{{") && strings.HasSuffix(bracketValue, "}}") {
+				bracketValue = strings.TrimPrefix(bracketValue, "{{")
+				bracketValue = strings.TrimSuffix(bracketValue, "}}")
+			}
+
+			// Handle numeric index
+			if index, err := strconv.Atoi(bracketValue); err == nil {
+				// Use list logic only if this looks like an actual list
+				if looksLikeListAttribute(base, lines) {
+					substr1 = base
+					substr2 = resolveListIndex(base, index, lines)
+					return substr1, substr2
+				}
+				// Otherwise treat it as a block navigation
+				substr1 = base
+				substr2 = "" // no value needed
+				return substr1, substr2
+			}
+
+			// Resource label or map key
+			substr1 = base
+			substr2 = bracketValue
+			return substr1, substr2
+		}
+	}
+
+	// Fallback: key = value
+	parts := strings.SplitN(key, "=", 2)
+	substr1 = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		substr2 = strings.TrimSpace(parts[1])
+	}
+
+	// Final fallback: try to resolve value from lines
+	if substr2 == "" && substr1 != "" {
+		for i := currentLine; i < len(lines); i++ {
+			line := lines[i]
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, substr1+" =") {
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) == 2 {
+					substr2 = strings.TrimSpace(parts[1])
+				}
+				break
+			}
+		}
+	}
+
+	return substr1, substr2
+}
+
+func looksLikeListAttribute(attrName string, lines []string) bool {
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, attrName+" = [") {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveListIndex(attrName string, index int, lines []string) string {
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, attrName+" = [") {
+			start := strings.Index(trimmed, "[")
+			end := strings.Index(trimmed, "]")
+			if start >= 0 && end > start {
+				items := strings.Split(trimmed[start+1:end], ",")
+				if index < len(items) {
+					return strings.Trim(strings.TrimSpace(items[index]), `"`)
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/detector/terraform/terraform_helper_test.go
+++ b/pkg/detector/terraform/terraform_helper_test.go
@@ -1,0 +1,119 @@
+package terraform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSubstrings(t *testing.T) {
+	lines := []string{
+		`tags = ["a", "b", "c"]`,
+		`description = "hello"`,
+		`name = "web"`,
+		`labels = { Name = "db" }`,
+	}
+
+	tests := []struct {
+		name        string
+		key         string
+		extracted   [][]string
+		currentLine int
+		wantSubstr1 string
+		wantSubstr2 string
+	}{
+		{
+			name:        "list index resolves to value",
+			key:         `tags[1]`,
+			currentLine: 0,
+			wantSubstr1: "tags",
+			wantSubstr2: "b",
+		},
+		{
+			name:        "numeric bracket but not a list -> block navigation (no value)",
+			key:         `ingress[0]`,
+			currentLine: 0,
+			wantSubstr1: "ingress",
+			wantSubstr2: "",
+		},
+		{
+			name:        "map-style quoted key",
+			key:         `labels["Name"]`,
+			currentLine: 0,
+			wantSubstr1: "labels",
+			wantSubstr2: "Name",
+		},
+		{
+			name:        "unquoted label key",
+			key:         `resource[web]`,
+			currentLine: 0,
+			wantSubstr1: "resource",
+			wantSubstr2: "web",
+		},
+		{
+			name:        "placeholder inside brackets gets restored",
+			key:         `labels[{{0}}]`,
+			extracted:   [][]string{{"Environment"}},
+			currentLine: 0,
+			wantSubstr1: "labels",
+			wantSubstr2: "Environment",
+		},
+		{
+			name:        "plain key=value line",
+			key:         `description = "hello"`,
+			currentLine: 0,
+			wantSubstr1: "description",
+			// Note: function preserves quotes from the right-hand side
+			wantSubstr2: `"hello"`,
+		},
+		{
+			name:        "fallback scan resolves value later in lines",
+			key:         `name`,
+			currentLine: 0,
+			wantSubstr1: "name",
+			wantSubstr2: `"web"`,
+		},
+		{
+			name:        "numeric placeholder but not list -> treated as block navigation (no value)",
+			key:         `block[{{0}}]`,
+			extracted:   [][]string{{"0"}},
+			currentLine: 0,
+			wantSubstr1: "block",
+			wantSubstr2: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got1, got2 := GenerateSubstrings(context.TODO(), tt.key, tt.extracted, lines, tt.currentLine)
+			require.Equal(t, got1, tt.wantSubstr1)
+			require.Equal(t, got2, tt.wantSubstr2)
+		})
+	}
+}
+
+func TestLooksLikeListAttribute(t *testing.T) {
+	lines := []string{
+		`tags = ["a", "b", "c"]`,
+		`ingress {}`,
+	}
+
+	require.Equal(t, looksLikeListAttribute("tags", lines), true)
+
+	require.Equal(t, looksLikeListAttribute("ingress", lines), false)
+}
+
+func TestResolveListIndex(t *testing.T) {
+	lines := []string{
+		`tags = ["a", "b", "c"]`,
+		`names = ["web"]`,
+	}
+
+	require.Equal(t, resolveListIndex("tags", 2, lines), "c")
+
+	require.Equal(t, resolveListIndex("tags", 5, lines), "")
+
+	require.Equal(t, resolveListIndex("names", 0, lines), "web")
+}

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -52,6 +52,11 @@ func resolveModulePath(source string, rootDir string) string {
 	return filepath.Clean(filepath.Join(rootDir, clean))
 }
 
+func isTerraformFile(filePath string) bool {
+	re := regexp.MustCompile(`(?i)^.*\.tf$`)
+	return re.MatchString(filePath)
+}
+
 // ParseTerraformModules parses HCL content and extracts module source/version, resolving locals/variables if possible.
 func ParseTerraformModules(ctx context.Context, files model.FileMetadatas) (map[string]ParsedModule, error) {
 	logger := logger.FromContext(ctx)
@@ -61,6 +66,10 @@ func ParseTerraformModules(ctx context.Context, files model.FileMetadatas) (map[
 
 	for _, file := range files {
 		filePath := file.FilePath
+		isTfFile := isTerraformFile(filePath)
+		if !isTfFile {
+			continue
+		}
 		baseDir := filepath.Dir(filePath)
 
 		file.Content = getFileContent(file)

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -53,8 +53,7 @@ func resolveModulePath(source string, rootDir string) string {
 }
 
 func isTerraformFile(filePath string) bool {
-	re := regexp.MustCompile(`(?i)^.*\.tf$`)
-	return re.MatchString(filePath)
+	return strings.HasSuffix(strings.ToLower(filePath), ".tf")
 }
 
 // ParseTerraformModules parses HCL content and extracts module source/version, resolving locals/variables if possible.
@@ -66,8 +65,7 @@ func ParseTerraformModules(ctx context.Context, files model.FileMetadatas) (map[
 
 	for _, file := range files {
 		filePath := file.FilePath
-		isTfFile := isTerraformFile(filePath)
-		if !isTfFile {
+		if !isTerraformFile(filePath) {
 			continue
 		}
 		baseDir := filepath.Dir(filePath)

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -98,7 +98,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string, extraInfos map[s
 		QueriesPath:                 []string{"./assets/queries"},
 		LibrariesPath:               "./assets/libraries",
 		ReportFormats:               []string{"sarif"},
-		Platform:                    []string{"Terraform"},
+		Platform:                    []string{"CICD", "Terraform"},
 		TerraformVarsPath:           "",
 		QueryExecTimeout:            60,
 		LineInfoPayload:             false,


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- Add a new framework to the IaC scanning

**Proposed Changes**
See the [enable framework page in Confluence](https://datadoghq.atlassian.net/wiki/spaces/Vulnerabil/pages/5458068295/Add+a+new+platform+framework)
- Enable the framework
This was done by changing the client.go and the assets.go.
- Ignore the non-Terraform files is for the ParseTerraformModules function that should not log a noisy error when trying to parse a file that is not even terraform. The function is not supposed to work, so it is no error.
- Added a multiline support in case the search key is a multiline string
This is because we are looking for the searchKey on each line, although a searchKey may me multiline. In this case, we look on multiple lines to try and find it. Currently, this is only for yaml files. I am not sure we need it for anything else
- Fixed the GetBracketValues function :
The function was broken: it was trying to escape variables inside {{ }}, but it was not working sometimes when there were {{inside the {{ }} themselves}}. Therefore, changed the function.
- Changed also the GenerateSubstrings function
Reverted it back to the original KICS state: changing it to make it work for terraform broke it for the others, so decided to put the terraform function in a specific terraform_helper.go file instead.
- Added resourceType and resourceName to the queries. This ensures that we have them on the front end.

I submit this contribution under the Apache-2.0 license.