### PR TITLE
ignore remediation that can cause issues for empty resources

### DIFF
--- a/assets/queries/terraform/aws/imdsv1_is_enabled/query.rego
+++ b/assets/queries/terraform/aws/imdsv1_is_enabled/query.rego
@@ -92,7 +92,7 @@ CxPolicy[result] {
         "keyExpectedValue": "metadata_options must be defined with http_tokens set to 'required'",
         "keyActualValue": "metadata_options is missing, defaulting to IMDSv1",
         "searchLine": common_lib.build_search_line(["resource", resource_type, name], []),
-        "remediation": "metadata_options {\n\t  http_tokens = \"required\"\n}",
+        #"remediation": "metadata_options {\n\t  http_tokens = \"required\"\n}",
         "remediationType": "addition"
     }
 }
@@ -178,7 +178,7 @@ CxPolicy[result] {
         "keyExpectedValue": sprintf("%s must be defined with http_tokens set to 'required'", [keyToCheck]),
         "keyActualValue": sprintf("%s is missing, defaulting to IMDSv1", [keyToCheck]),
         "searchLine": common_lib.build_search_line(["module", name], []),
-        "remediation": sprintf("%s {\n\t  http_tokens = \"required\"\n}", keyToCheck),
+        #"remediation": sprintf("%s {\n\t  http_tokens = \"required\"\n}", keyToCheck),
         "remediationType": "addition"
     }
 }


### PR DESCRIPTION
Can caused mangled terraform as seen https://github.com/DataDog/chris-iac-scanning-test/pull/36/files if applied to completely empty resources
If resource is not completely empty, appears to apply properly https://github.com/DataDog/chris-iac-scanning-test/pull/37/files