### PR TITLE
[WIP][K9VULN-7977] Add platform to sarif output

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -54,6 +54,7 @@ type ruleMetadata struct {
 	queryURI         string
 	queryCategory    string
 	queryCwe         string
+	queryPlatform    string
 	severity         model.Severity
 }
 
@@ -117,6 +118,7 @@ type sarifRule struct {
 	RuleName             string              `json:"name"`
 	RuleShortDescription sarifMessage        `json:"shortDescription"`
 	RuleFullDescription  sarifMessage        `json:"fullDescription"`
+	Platform             string              `json:"platform"`
 	DefaultConfiguration sarifConfiguration  `json:"defaultConfiguration"`
 	HelpURI              string              `json:"helpUri"`
 	Relationships        []sarifRelationship `json:"relationships,omitempty"`
@@ -550,6 +552,7 @@ func (sr *sarifReport) buildSarifRule(queryMetadata *ruleMetadata, cisMetadata r
 			RuleProperties: sarifProperties{
 				"tags": tags,
 			},
+			Platform: queryMetadata.queryPlatform,
 		}
 		if cisMetadata.id != "" {
 			rule.RuleFullDescription.Text = cisMetadata.descriptionText
@@ -598,6 +601,11 @@ func (sr *sarifReport) RebuildTaxonomies(cwes []string, guids map[string]string)
 // BuildSarifIssue creates a new entries in Results (one for each file) and new entry in Rules and Taxonomy if necessary
 func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryResult, sciInfo model.SCIInfo) string {
 	logger := logger.FromContext(ctx)
+	logger.Debug().Msg(issue.Platform)
+	logger.Debug().Msg(issue.Platform)
+	logger.Debug().Msg(issue.Platform)
+	logger.Debug().Msg(issue.Platform)
+	logger.Debug().Msg(issue.Platform)
 	if len(issue.Files) > 0 {
 		metadata := ruleMetadata{
 			queryID:          issue.QueryID,
@@ -606,6 +614,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 			queryURI:         issue.QueryURI,
 			queryCategory:    issue.Category,
 			queryCwe:         issue.CWE,
+			queryPlatform:    issue.Platform,
 			severity:         issue.Severity,
 		}
 		cisDescriptions := ruleCISMetadata{


### PR DESCRIPTION
Refs; K9VULN-7977

Closes #

**Reason for Proposed Changes**
- Some different frameworks use the same language. Some customers may however want to 

**Proposed Changes**
- Add the platform field in the SARIF output

I submit this contribution under the Apache-2.0 license.