### PR TITLE
Reduce logging level for unsupported file ext from "Error" to "Info"

### DIFF
--- a/pkg/utils/get_extension.go
+++ b/pkg/utils/get_extension.go
@@ -31,7 +31,7 @@ func GetExtension(ctx context.Context, path string) (string, error) {
 
 	if fileInfo.IsDir() {
 		err = fmt.Errorf("the path %s is a directory", path)
-		logger.Error().Msg(err.Error())
+		logger.Info().Msg(err.Error())
 		return "", err
 	}
 
@@ -50,7 +50,7 @@ func GetExtension(ctx context.Context, path string) (string, error) {
 
 			if isText {
 				err := fmt.Errorf("file %s does not have a supported extension", path)
-				logger.Error().Msg(err.Error())
+				logger.Info().Msg(err.Error())
 				return "", err
 			}
 		}


### PR DESCRIPTION
**Reason for Proposed Changes**
- A lot of noise is generated at "Error" level by those logs that are juste expected when scanning full repos with collections of miscellaneous unscannable files.

**Proposed Changes**
- Those should be at the highest "Info" (or even "Debug"/removed altogether)

I submit this contribution under the Apache-2.0 license.