### PR TITLE
Added cause to failed yaml parsing

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -631,7 +631,7 @@ func isExcludedFile(ctx context.Context, path string, exc []string) bool {
 		}
 		for j := range exclude {
 			if exclude[j] == path {
-				// logger.Info().Msgf("Excluded file %s from analyzer", path)
+				logger.Info().Msgf("Excluded file %s from analyzer", path)
 				return true
 			}
 		}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -631,7 +631,7 @@ func isExcludedFile(ctx context.Context, path string, exc []string) bool {
 		}
 		for j := range exclude {
 			if exclude[j] == path {
-				logger.Info().Msgf("Excluded file %s from analyzer", path)
+				// logger.Info().Msgf("Excluded file %s from analyzer", path)
 				return true
 			}
 		}

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -44,25 +44,20 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 	dec := yaml.NewDecoder(bytes.NewReader(fileContent))
 
 	doc := emptyDocument()
-	decoded := dec.Decode(doc)
-	for decoded == nil {
+	var err error
+	for {
+		if err = dec.Decode(doc); err != nil {
+			break
+		}
 		if len(*doc) > 0 {
 			documents = append(documents, *doc)
 		}
 
 		doc = emptyDocument()
-		decoded = dec.Decode(doc)
 	}
 
 	if len(documents) == 0 {
-		var error error
-		switch decoded.Error() {
-		case "EOF":
-			error = errors.New("invalid yaml")
-		default:
-			error = decoded
-		}
-		return nil, []int{}, errors.Wrap(error, "failed to parse yaml")
+		return nil, []int{}, errors.Wrap(err, "failed to parse yaml")
 	}
 
 	linesToIgnore := model.NewIgnore.GetLines()


### PR DESCRIPTION
Added the reason to why we can't parse a yaml file

I submit this contribution under the Apach
<img width="1465" height="333" alt="Screenshot 2025-09-25 at 12 05 38" src="https://github.com/user-attachments/assets/3da18b61-e4fe-41d1-8e46-5cbeaccf59cc" />
e-2.0 license.