### PR TITLE
[K9VULN-6132] Change ViolationBreakdowns to count rule violations

### DIFF
--- a/pkg/scan/metadata.go
+++ b/pkg/scan/metadata.go
@@ -29,7 +29,7 @@ type ScanStats struct {
 	// Duration contains the time it took to complete the analysis.
 	Duration time.Duration
 	// ViolationBreakdowns contains a breakdown of the violations by severity.
-	ViolationBreakdowns map[string][]string
+	ViolationBreakdowns map[string]map[string]int
 	// ResourcesFound contains the number of resources that were analyzed.
 	ResourcesScanned int
 }

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -209,19 +209,23 @@ func (c *Client) generateMetadata(scanResults *Results, startTime time.Time, end
 
 func (c *Client) generateStats(scanResults *Results, scanDuration time.Duration) ScanStats {
 	// iterate through scanResults and create a map of severity to count
-	violationBreakdowns := make(map[string][]string)
+	violationBreakdowns := make(map[string]map[string]int)
 	severitySet := make(map[model.Severity]bool)
 	for _, sev := range model.AllSeverities {
 		severitySet[sev] = true
 	}
+
 	for _, vuln := range scanResults.Results {
-		if _, exists := severitySet[vuln.Severity]; exists {
-			temp := []string{}
-			if _, exists := violationBreakdowns[string(vuln.Severity)]; exists {
-				temp = violationBreakdowns[string(vuln.Severity)]
-			}
-			violationBreakdowns[string(vuln.Severity)] = append(temp, vuln.QueryID)
+		if !severitySet[vuln.Severity] {
+			continue
 		}
+
+		if _, exists := violationBreakdowns[string(vuln.Severity)]; !exists {
+			violationBreakdowns[string(vuln.Severity)] = make(map[string]int)
+		}
+
+
+		violationBreakdowns[string(vuln.Severity)][vuln.QueryID]++
 	}
 
 	return ScanStats{

--- a/pkg/scan/post_scan_test.go
+++ b/pkg/scan/post_scan_test.go
@@ -403,8 +403,8 @@ func Test_GetScanMetadata(t *testing.T) {
 					Files:      1,
 					Rules:      1,
 					Duration:   time.Minute,
-					ViolationBreakdowns: map[string][]string{
-						"MEDIUM": {"c065b98e-1515-4991-9dca-b602bd6a2fbb"},
+					ViolationBreakdowns: map[string]map[string]int{
+						"MEDIUM": {"c065b98e-1515-4991-9dca-b602bd6a2fbb": 1},
 					},
 				},
 				RuleStats: RuleStats{
@@ -431,9 +431,8 @@ func Test_GetScanMetadata(t *testing.T) {
 			v := c.generateMetadata(tt.results, tt.scanStartTime, tt.endTime)
 
 			require.Equal(t, tt.expectedMetadata.StartTime, v.StartTime)
-			require.Equal(t, len(tt.expectedMetadata.Stats.ViolationBreakdowns), len(v.Stats.ViolationBreakdowns))
 			require.Equal(t, tt.expectedMetadata.Stats.Violations, v.Stats.Violations)
-			require.Equal(t, tt.expectedMetadata.Stats.ViolationBreakdowns["MEDIUM"], v.Stats.ViolationBreakdowns["MEDIUM"])
+			require.Equal(t, tt.expectedMetadata.Stats.ViolationBreakdowns, v.Stats.ViolationBreakdowns)
 		})
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,12 +21,20 @@ func Test_E2EExclusions(t *testing.T) {
 			name:     "no exclusions",
 			testFile: filepath.Join("fixtures", "no-exclusions.tf"),
 			expectedOutput: scan.ScanStats{
-				Violations: 6,
+				Violations: 5,
 				Files:      1,
-				Rules:      1126,
-				ViolationBreakdowns: map[string][]string{
-					"LOW":    {"c5b31ab9-0f26-4a49-b8aa-4cc064392f4d", "e592a0c5-5bdb-414c-9066-5dba7cdea370", "c5b31ab9-0f26-4a49-b8aa-4cc064392f4d"},
-					"MEDIUM": {"f861041c-8c9f-4156-acfc-5e6e524f5884", "568a4d22-3517-44a6-a7ad-6a7eed88722c"},
+				Rules:      1124,
+				ViolationBreakdowns: map[string]map[string]int{
+					"INFO":   {
+						"a2b3c4d5-e6f7-8901-gh23-ijkl456m7890": 1,
+					},
+					"LOW":    {
+						"c5b31ab9-0f26-4a49-b8aa-4cc064392f4d": 2,
+					},
+					"MEDIUM": {
+						"f861041c-8c9f-4156-acfc-5e6e524f5884": 1,
+						"568a4d22-3517-44a6-a7ad-6a7eed88722c": 1,
+					},
 				},
 			},
 		},
@@ -34,12 +42,17 @@ func Test_E2EExclusions(t *testing.T) {
 			name:     "disabled rule inline",
 			testFile: filepath.Join("fixtures", "inline-disabled-rule.tf"),
 			expectedOutput: scan.ScanStats{
-				Violations: 5,
+				Violations: 4,
 				Files:      1,
-				Rules:      1126,
-				ViolationBreakdowns: map[string][]string{
-					"LOW":    {"c5b31ab9-0f26-4a49-b8aa-4cc064392f4d", "c5b31ab9-0f26-4a49-b8aa-4cc064392f4d"},
-					"MEDIUM": {"f861041c-8c9f-4156-acfc-5e6e524f5884", "568a4d22-3517-44a6-a7ad-6a7eed88722c"},
+				Rules:      1124,
+				ViolationBreakdowns: map[string]map[string]int{
+					"LOW":    {
+						"c5b31ab9-0f26-4a49-b8aa-4cc064392f4d": 2,
+					},
+					"MEDIUM": {
+						"f861041c-8c9f-4156-acfc-5e6e524f5884": 1,
+						"568a4d22-3517-44a6-a7ad-6a7eed88722c": 1,
+					},
 				},
 			},
 		},
@@ -67,8 +80,7 @@ func Test_E2EExclusions(t *testing.T) {
 			require.Equal(t, tt.expectedOutput.Violations, metadata.Stats.Violations)
 			require.Equal(t, tt.expectedOutput.Files, metadata.Stats.Files)
 			require.Equal(t, tt.expectedOutput.Rules, metadata.Stats.Rules)
-			require.ElementsMatch(t, tt.expectedOutput.ViolationBreakdowns["LOW"], metadata.Stats.ViolationBreakdowns["LOW"])
-			require.ElementsMatch(t, tt.expectedOutput.ViolationBreakdowns["MEDIUM"], metadata.Stats.ViolationBreakdowns["MEDIUM"])
+			require.Equal(t, tt.expectedOutput.ViolationBreakdowns, metadata.Stats.ViolationBreakdowns)
 		})
 	}
 

--- a/test/e2e/fixtures/inline-disabled-rule.tf
+++ b/test/e2e/fixtures/inline-disabled-rule.tf
@@ -1,4 +1,4 @@
-# dd-iac-scan disable=e592a0c5-5bdb-414c-9066-5dba7cdea370
+# dd-iac-scan disable=a2b3c4d5-e6f7-8901-gh23-ijkl456m7890
 provider "aws" {
   region = "us-east-1"
 }


### PR DESCRIPTION
Aggregate the count per rule in `ViolationBreakdowns` so it’s easier to report as a Distribution metric later.

Refs: K9VULN-6132

I submit this contribution under the Apache-2.0 license.